### PR TITLE
Make RELION-US the sole pipeline writer for job status; add picking Run/Done/Continue/Overwrite

### DIFF
--- a/backend/custom_jobs.py
+++ b/backend/custom_jobs.py
@@ -314,20 +314,35 @@ async def run_manual_pick(project_dir: Path, values: dict, job_dir: Path) -> str
     resolve to something real and reports how many, so the popup's summary
     line isn't blank. The actual picking happens afterward, through the
     Picker button (app.js), which reads/writes this job's own directory via
-    /api/manual-pick/{run_id}/spa/* -- see manual_pick.py. Completing
-    immediately (rather than staying "running" the way real RELION's
-    Manualpick does while its picker window is open) is deliberate: this
-    app's job-run model is one-shot, and there is no harm in a "completed"
-    job whose output directory keeps gaining picks after the fact -- Extract
-    reads whatever manualpick.star says at ITS OWN run time, same as it
-    would for a real Manualpick job reopened and re-picked."""
+    /api/manual-pick/{run_id}/spa/* -- see manual_pick.py.
+
+    main.py passes stays_running=True for this job (is_picker), so a
+    successful return here leaves the run "running", not "completed" --
+    see job_runner.JobRunManager.start_custom_job's own docstring. The user
+    ends the session explicitly (the "Done" button, job_runner.set_status)
+    when they're actually finished picking, and can come back to a
+    "completed" one non-destructively (job_runner.resume_run, the toolbar's
+    "Continue" action -- reads whatever's already there, changes nothing).
+
+    Overwrite reuses this SAME function (start_custom_job's overwrite_
+    run_id path), which is why clearing prior picks lives HERE rather than
+    behind a separate "is this an overwrite" flag: a fresh run's directory
+    is always empty, so clear_spa_picks is a no-op there and only actually
+    removes anything on a genuine Overwrite -- matching real RELION's own
+    "Overwrite re-runs into the SAME directory" semantics (gui_mainwindow.
+    cpp's cb_toggle_overwrite_continue), the destructive counterpart to
+    Continue above.
+    """
     fn_in = values.get("fn_in", "")
     if not fn_in:
         raise ValueError("Input micrographs field is required.")
 
     def work():
+        removed = manual_pick.clear_spa_picks(job_dir)
         mics = manual_pick.list_spa_micrographs(project_dir, fn_in)
+        cleared_note = f"Cleared {removed} existing pick file(s) from a previous run.\n" if removed else ""
         return (
+            f"{cleared_note}"
             f"Found {len(mics)} micrograph(s) in {fn_in}.\n"
             f"Use the Picker button above to open the viewer and start picking "
             f"-- picks save into this job's own directory as you go, and this "
@@ -339,19 +354,23 @@ async def run_manual_pick(project_dir: Path, values: dict, job_dir: Path) -> str
 
 
 async def run_tomo_manual_pick(project_dir: Path, values: dict, job_dir: Path) -> str:
-    """Tomogram counterpart of run_manual_pick above -- same one-shot-
-    completion reasoning. Only point picking (pick_mode "Particles") is
-    wired up on the viewer side right now; other pick_mode choices (helical
-    filaments, spheres, surfaces) still round-trip into job.star (real
-    RELION option, kept for a native-GUI-repair later) but the picker
-    doesn't yet do anything different for them."""
+    """Tomogram counterpart of run_manual_pick above -- same stays_running /
+    Done / Continue / Overwrite-clears-first reasoning (see its docstring).
+    Only point picking (pick_mode "Particles") is wired up on the viewer
+    side right now; other pick_mode choices (helical filaments, spheres,
+    surfaces) still round-trip into job.star (real RELION option, kept for
+    a native-GUI-repair later) but the picker doesn't yet do anything
+    different for them."""
     in_tomoset = values.get("in_tomoset", "")
     if not in_tomoset:
         raise ValueError("Input tomograms.star field is required.")
 
     def work():
+        removed = manual_pick.clear_tomo_picks(job_dir)
         tomograms = viz._tomograms_from_star(project_dir, viz._safe(project_dir, in_tomoset))
+        cleared_note = f"Cleared {removed} existing pick file(s) from a previous run.\n" if removed else ""
         return (
+            f"{cleared_note}"
             f"Found {len(tomograms)} tomogram(s) in {in_tomoset}.\n"
             f"Use the Picker button above to open the viewer and start picking "
             f"-- picks save into this job's own directory as you go, and this "

--- a/backend/job_runner.py
+++ b/backend/job_runner.py
@@ -57,8 +57,14 @@ STATUS_ABORTED = "aborted"
 # cb_mark_as_finished/cb_mark_as_failed) -- deliberately NOT the full status
 # set: you can't manually force a job back to "running"/"pending", and
 # "aborted" has its own dedicated action (abort_run) since it also has to
-# actually stop the process.
+# actually stop the process. resume_run() is the one deliberate, narrower
+# exception to "can't go back to running" -- restricted to the picking job
+# types (Manualpick/TomoManualPick), which have no real process to have
+# stopped in the first place; see its own docstring.
 MANUALLY_SETTABLE_STATUSES = {STATUS_COMPLETED, STATUS_FAILED}
+# Which statuses resume_run() will move back to "running" -- see its own
+# docstring (the toolbar's "Continue" action).
+RESUMABLE_STATUSES = {STATUS_COMPLETED, STATUS_FAILED}
 
 # Placeholder "command" recorded for custom (in-process converter) jobs, which
 # never spawn a subprocess. Kept as one constant so the marker and the check
@@ -236,6 +242,20 @@ class JobRun:
     # start_subprocess_job); this only means it won't show up in RELION's
     # own GUI, which is worth knowing rather than discovering later.
     pipeline_sync_error: Optional[str] = field(default=None, repr=False, compare=False)
+    # True once this run was actually registered with relion_pipeliner
+    # (register_job succeeded) -- as opposed to pipeline_sync_enabled()
+    # merely being on for the project, which register_job can still fail
+    # under (locked pipeline, unrecognised job type). Everything that
+    # writes directly into RELION's own pipeline afterward (marking
+    # Running when work starts, the exit-marker + --check_job_completion
+    # handshake when it ends -- see pipeline_bridge.set_process_status's
+    # own docstring for why that direct write exists at all) is gated on
+    # this, not on pipeline_sync_enabled() again: re-checking the project
+    # setting would try to talk to a process this app never actually told
+    # relion_pipeliner about. Persisted (to_summary()) so a "Done" click on
+    # a run from a previous backend session still knows whether to do the
+    # handshake.
+    pipeline_registered: bool = False
     # Set when Abort arrives before the subprocess handle exists (see
     # abort_run + _run_subprocess); the launcher honours it as soon as it
     # has a process to signal.
@@ -276,6 +296,7 @@ class JobRun:
             "field_values": self.field_values,
             "detected_inputs": self.detected_inputs,
             "abortable": self.status == STATUS_RUNNING and (self.proc is not None or self.task is not None),
+            "pipeline_registered": self.pipeline_registered,
         }
 
     async def broadcast(self, message: dict) -> None:
@@ -635,6 +656,31 @@ class JobRunManager:
             return False
         return pipeline_bridge.check_job_completion(pd)
 
+    @staticmethod
+    def _mark_pipeline_running(run: JobRun) -> None:
+        """The direct-write half of the fix for jobs sitting forever as
+        "Scheduled" in RELION's own GUI -- see pipeline_bridge.
+        set_process_status's own docstring for the full story
+        (--check_job_completion only ever promotes a process already marked
+        "Running", and relion_pipeliner's CLI has no other way to get one
+        there without actually re-executing its real command). Called once,
+        right when real work starts, for any run that was actually
+        registered (run.pipeline_registered) -- best-effort: a failure here
+        (lock contention, pipeline file vanished) must never block the real
+        work itself from starting, so it's swallowed, the same as _persist's
+        own history-write failures.
+        """
+        if not run.pipeline_registered:
+            return
+        try:
+            process_name = str(Path(run.cwd).relative_to(run.project_dir))
+        except ValueError:
+            return
+        try:
+            pipeline_bridge.set_process_status(Path(run.project_dir), process_name, "Running")
+        except pipeline_bridge.PipelineBridgeError:
+            pass
+
     def _next_job_number(self, project_dir: Path, internal_name: Optional[str] = None) -> int:
         """RELION's own job numbering is a single counter for the whole
         project, shared across every job type (see job_catalog.py's
@@ -684,7 +730,9 @@ class JobRunManager:
         n = self._next_job_number(pd, internal_name)
         return f"{job_catalog.job_dirname(internal_name)}/job{n:03d}"
 
-    def _resolve_overwrite_target(self, overwrite_run_id: str, project_dir: Path) -> dict:
+    def _resolve_overwrite_target(
+        self, overwrite_run_id: str, project_dir: Path, allow_running: bool = False
+    ) -> dict:
         """Looks up the run being overwritten, whether it's still live in
         self.runs (this session), only survives in persisted history (a
         previous session), or -- for the read-only callers, i.e. draft
@@ -694,7 +742,18 @@ class JobRunManager:
         of that job's job.star). Overwrite should work either way, the
         same as delete_run()/file operations above. Raises ValueError
         (caller turns this into a 409) if the run can't be found, is still
-        running, or belongs to a different/inactive project.
+        running (unless allow_running), or belongs to a different/inactive
+        project.
+
+        allow_running: a picker job (Manualpick/TomoManualPick) sits at
+        STATUS_RUNNING for the whole picking session (see start_custom_job's
+        stays_running) -- for it, "running" doesn't mean "compute in
+        progress," it means "picking session open," and Overwrite pressed
+        during that session is exactly the "refresh the job directory"
+        action the user asked for. Only start_custom_job passes True here,
+        and only for stays_running jobs; start_subprocess_job's real
+        compute jobs keep the default (a genuinely-running subprocess must
+        never be overwritten out from under itself).
 
         Resolving a RELION-native run here does NOT reopen the door on
         actually overwriting one: start_subprocess_job's overwrite_run_id
@@ -725,7 +784,7 @@ class JobRunManager:
                 "cwd": entry.get("cwd"), "job_number": entry.get("job_number", 0),
                 "alias": entry.get("alias", ""), "note": entry.get("note", ""),
             }
-        if info["status"] == STATUS_RUNNING:
+        if info["status"] == STATUS_RUNNING and not allow_running:
             raise ValueError("Cannot overwrite a job that is still running")
         if info["project_dir"] != str(project_dir):
             raise ValueError("Cannot overwrite a job from a different/inactive project")
@@ -807,6 +866,7 @@ class JobRunManager:
         project_dir = self.project_dir
         rewrite_note = None
         pipeline_sync_error = None
+        pipeline_registered = False
 
         if overwrite_run_id is not None:
             target = self._resolve_overwrite_target(overwrite_run_id, project_dir)
@@ -878,6 +938,7 @@ class JobRunManager:
                     )
                 if self.pipeline_sync_enabled(project_dir):
                     command = pipeline_bridge.pipeline_control_args(command, authoritative_subdir)
+                    pipeline_registered = True
         else:
             run_id = self.new_run_id()
             registered = None
@@ -921,6 +982,7 @@ class JobRunManager:
                 # "Running". Without the flag the job would sit as Running in
                 # RELION's GUI forever.
                 command = pipeline_bridge.pipeline_control_args(command, authoritative_subdir)
+                pipeline_registered = True
                 pipeline_note = (
                     f"[RELION-US] Registered in RELION's pipeline as "
                     f"{authoritative_subdir}/ — it will appear in RELION's own GUI."
@@ -948,6 +1010,7 @@ class JobRunManager:
             note=note,
             field_values=field_values,
             detected_inputs=_detect_inputs(detect_text, project_dir, cwd),
+            pipeline_registered=pipeline_registered,
         )
         run.rewrite_note = rewrite_note
         run.pipeline_sync_error = pipeline_sync_error
@@ -966,6 +1029,9 @@ class JobRunManager:
         run.started_at = time.time()
         self._persist(run)
         await run.broadcast({"type": "status", "status": run.status})
+        # Off the event loop: this may wait on the pipeline lock -- see
+        # _mark_pipeline_running's own docstring.
+        await asyncio.to_thread(self._mark_pipeline_running, run)
 
         # If start_subprocess_job had to advance the output directory to
         # avoid a job-number collision, surface that one adjustment in the
@@ -1133,6 +1199,7 @@ class JobRunManager:
         runner_coro_factory,
         field_values: Optional[dict] = None,
         overwrite_run_id: Optional[str] = None,
+        stays_running: bool = False,
     ) -> JobRun:
         """
         runner_coro_factory: a callable taking the job's own output directory
@@ -1152,22 +1219,33 @@ class JobRunManager:
         ones. Same restrictions (must exist, not still running, same
         project) apply.
 
+        stays_running: the runner_coro_factory only VALIDATES its inputs and
+        returns immediately (the Manualpick/TomoManualPick picking jobs --
+        the real work is picking, done afterward through the Picker button
+        against this job's own directory, not by this coroutine). When True,
+        a successful return leaves the run at STATUS_RUNNING instead of
+        completing it -- see set_status(), which is what actually finishes
+        it (the "Done" button) once the user says so. A raised exception
+        still fails/aborts the run normally either way; only the success
+        path is affected.
+
         Registers in RELION's own pipeline the same way start_subprocess_job
         does (when two-way sync is on) -- a custom job is real work with real
         outputs, and a user who turned sync on wants to see ALL their jobs in
         RELION's own GUI, not just the ones that happen to shell out to a
         real relion_* binary. There is no real subprocess here for
-        `--pipeline_control` to instrument, so _run_custom writes the
-        RELION_JOB_EXIT_* marker file itself once the coroutine finishes --
-        the same file a real RELION program would have written, which is all
-        `relion_pipeliner --check_job_completion` (called from there, exactly
-        like _run_subprocess) actually looks for.
+        `--pipeline_control` to instrument, so _run_custom marks the process
+        "Running" itself the moment work starts, and (unless stays_running)
+        writes the RELION_JOB_EXIT_* marker file once the coroutine finishes
+        -- see pipeline_bridge.set_process_status's own docstring for why
+        both of those are needed, not just the latter.
         """
         project_dir = self.project_dir
         pipeline_sync_error = None
 
         if overwrite_run_id is not None:
-            target = self._resolve_overwrite_target(overwrite_run_id, project_dir)
+            target = self._resolve_overwrite_target(
+                overwrite_run_id, project_dir, allow_running=stays_running)
             run_id = overwrite_run_id
             cwd = Path(target["cwd"])
             job_number = target["job_number"]
@@ -1213,15 +1291,16 @@ class JobRunManager:
             field_values=field_values,
             pipeline_sync_error=pipeline_sync_error,
             detected_inputs=_detect_inputs(detect_text, project_dir, cwd),
+            pipeline_registered=bool(registered),
         )
         self.runs[run_id] = run
         self._persist(run)
         run.task = asyncio.create_task(
-            self._run_custom(run, runner_coro_factory, cwd, registered=bool(registered)))
+            self._run_custom(run, runner_coro_factory, cwd, stays_running=stays_running))
         return run
 
     async def _run_custom(
-        self, run: JobRun, runner_coro_factory, job_dir: Path, registered: bool = False
+        self, run: JobRun, runner_coro_factory, job_dir: Path, stays_running: bool = False
     ) -> None:
         if run.abort_requested:
             return  # aborted before this task got scheduled; see _run_subprocess
@@ -1229,16 +1308,25 @@ class JobRunManager:
         run.started_at = time.time()
         self._persist(run)
         await run.broadcast({"type": "status", "status": run.status})
+        # Off the event loop: this may wait on the pipeline lock -- see
+        # _mark_pipeline_running's own docstring.
+        await asyncio.to_thread(self._mark_pipeline_running, run)
         if run.pipeline_sync_error:
             run.stderr_lines.append(run.pipeline_sync_error)
             await run.broadcast({"type": "stderr", "line": run.pipeline_sync_error})
+        stayed_running = False
         try:
             result = await runner_coro_factory(job_dir)
             for line in str(result).splitlines() or ["(no output)"]:
                 run.stdout_lines.append(line)
                 await run.broadcast({"type": "stdout", "line": line})
-            run.status = STATUS_COMPLETED
-            run.exit_code = 0
+            if stays_running:
+                # Validated, not finished -- see start_custom_job's own
+                # docstring. set_status() (the Done button) finishes it.
+                stayed_running = True
+            else:
+                run.status = STATUS_COMPLETED
+                run.exit_code = 0
         except asyncio.CancelledError:
             run.status = STATUS_ABORTED
             run.stderr_lines.append("Aborted by user.")
@@ -1250,29 +1338,49 @@ class JobRunManager:
             run.status = STATUS_FAILED
             run.exit_code = 1
         finally:
-            run.ended_at = time.time()
+            if not stayed_running:
+                run.ended_at = time.time()
             self._persist(run)
-            if registered:
-                marker = {
-                    STATUS_COMPLETED: "RELION_JOB_EXIT_SUCCESS",
-                    STATUS_FAILED: "RELION_JOB_EXIT_FAILURE",
-                    STATUS_ABORTED: "RELION_JOB_EXIT_ABORTED",
-                }.get(run.status)
-                if marker:
-                    try:
-                        (job_dir / marker).touch()
-                    except OSError:
-                        pass
-                synced = await asyncio.to_thread(
-                    self.sync_completion_to_relion, Path(run.project_dir))
-                if not synced:
-                    note = ("[RELION-US] Could not update RELION's pipeline with this "
-                            "job's final status. The job itself is unaffected; run "
-                            "`relion_pipeliner --check_job_completion` in the project, "
-                            "or open RELION's GUI, to refresh it.")
-                    run.stdout_lines.append(note)
-                    await run.broadcast({"type": "stdout", "line": note})
+            if run.pipeline_registered and not stayed_running:
+                await self._finish_pipeline_registration(run, job_dir)
             await run.broadcast({"type": "status", "status": run.status, "exit_code": run.exit_code})
+
+    async def _write_exit_marker_and_sync(self, status: str, project_dir: Path, job_dir: Path) -> bool:
+        """The exit-marker + --check_job_completion handshake for a
+        registered run reaching a terminal status -- writes the
+        RELION_JOB_EXIT_* file a real relion_* program would have written
+        (see pipeline_control.h) into job_dir, then calls relion_pipeliner
+        --check_job_completion off the event loop. Shared by every path
+        that finishes a registered run: _run_custom's own completion,
+        set_status()'s "Done"/"Mark as failed" (including a job that
+        deliberately stayed running until then -- see start_custom_job's
+        stays_running docstring), and the persisted-only fallback for a run
+        from a previous backend session. Returns whether the sync call
+        itself succeeded (the marker file is written either way)."""
+        marker = {
+            STATUS_COMPLETED: "RELION_JOB_EXIT_SUCCESS",
+            STATUS_FAILED: "RELION_JOB_EXIT_FAILURE",
+            STATUS_ABORTED: "RELION_JOB_EXIT_ABORTED",
+        }.get(status)
+        if marker:
+            try:
+                (job_dir / marker).touch()
+            except OSError:
+                pass
+        return await asyncio.to_thread(self.sync_completion_to_relion, project_dir)
+
+    async def _finish_pipeline_registration(self, run: JobRun, job_dir: Path) -> None:
+        """_write_exit_marker_and_sync for a LIVE run -- also surfaces a
+        sync failure into the run's own Errors tab, which the persisted
+        -only fallback (nothing subscribed to broadcast to) can't do."""
+        synced = await self._write_exit_marker_and_sync(run.status, Path(run.project_dir), job_dir)
+        if not synced:
+            note = ("[RELION-US] Could not update RELION's pipeline with this "
+                    "job's final status. The job itself is unaffected; run "
+                    "`relion_pipeliner --check_job_completion` in the project, "
+                    "or open RELION's GUI, to refresh it.")
+            run.stdout_lines.append(note)
+            await run.broadcast({"type": "stdout", "line": note})
 
     # --- Command Center job actions -----------------------------------
     # Real RELION job actions this mirrors (see gui_mainwindow.cpp's "Job
@@ -1531,7 +1639,7 @@ class JobRunManager:
         self._persist(run)
         return run.to_summary()
 
-    def set_status(self, run_id: str, status: str) -> Optional[dict]:
+    async def set_status(self, run_id: str, status: str) -> Optional[dict]:
         """Real RELION 'Mark as finished' / 'Mark as failed' job actions
         (gui_mainwindow.cpp's cb_mark_as_finished/cb_mark_as_failed) — a
         manual override for when a run's tracked status doesn't match what
@@ -1539,17 +1647,103 @@ class JobRunManager:
         process kept going/died outside this app's view). Restricted to
         MANUALLY_SETTABLE_STATUSES; raises ValueError otherwise so the API
         layer can turn that into a clean 400 rather than silently no-op'ing
-        or allowing a nonsensical manual "running"/"pending" override."""
+        or allowing a nonsensical manual "running"/"pending" override.
+
+        This is also the ONLY route to a terminal status for a run that
+        deliberately stays "running" until the user says otherwise (the
+        Manualpick/TomoManualPick picking jobs -- see start_custom_job's
+        stays_running parameter): its "Done" button calls this exactly like
+        "Mark as finished" does, which is what actually performs the
+        RELION-pipeline completion handshake (_write_exit_marker_and_sync)
+        for a registered run, not just a local status flip. Async now for
+        that reason -- the handshake calls out to relion_pipeliner.
+        """
         if status not in MANUALLY_SETTABLE_STATUSES:
             raise ValueError(f"status must be one of {sorted(MANUALLY_SETTABLE_STATUSES)}")
         run = self.get(run_id)
         if run is None:
-            return self._update_persisted_only(run_id, status=status)
+            history = project_manager.load_history(self.project_dir)
+            entry = next((h for h in history if h.get("run_id") == run_id), None)
+            if entry is None:
+                return None
+            if entry.get("pipeline_registered") and entry.get("project_dir") and entry.get("cwd"):
+                await self._write_exit_marker_and_sync(
+                    status, Path(entry["project_dir"]), Path(entry["cwd"]))
+            return self._update_persisted_only(run_id, status=status, ended_at=time.time())
         run.status = status
         if run.ended_at is None:
             run.ended_at = time.time()
         self._persist(run)
+        if run.pipeline_registered:
+            await self._finish_pipeline_registration(run, Path(run.cwd))
+        await run.broadcast({"type": "status", "status": run.status, "exit_code": run.exit_code})
         return run.to_summary()
+
+    async def resume_run(self, run_id: str) -> Optional[dict]:
+        """The picking jobs' "Continue" toolbar action -- the non
+        -destructive counterpart to Overwrite (which clears the job's
+        existing picks first, see custom_jobs.run_manual_pick's own
+        docstring): puts a finished run back to "running" WITHOUT touching
+        anything in its directory, so reopening the Picker shows exactly
+        the picks that were already there. Only meaningful for a run that
+        deliberately stays "running" until told otherwise (start_custom_
+        job's stays_running) rather than a real subprocess/compute job,
+        which genuinely finished and has nothing left to "resume" --
+        restricted to the picking job types at the API layer (main.py),
+        same as stays_running itself.
+
+        Raises ValueError if the run isn't in a resumable status.
+        Mirrors RelionJob's own re-run preamble
+        (pipeline_control_delete_exit_files, src/pipeline_control.cpp) --
+        clears any stale RELION_JOB_EXIT_*/ABORT_NOW files left over from
+        the previous session before marking it "Running" again, so a
+        --check_job_completion firing later (for this job or completely
+        unrelated ones sharing the same poll) can't immediately re-finish
+        it on a leftover marker nothing actually produced this time.
+        """
+        run = self.get(run_id)
+        if run is None:
+            history = project_manager.load_history(self.project_dir)
+            entry = next((h for h in history if h.get("run_id") == run_id), None)
+            if entry is None:
+                return None
+            if entry.get("status") not in RESUMABLE_STATUSES:
+                raise ValueError(f"status must be one of {sorted(RESUMABLE_STATUSES)} to resume")
+            if entry.get("cwd"):
+                self._delete_pipeline_control_files(Path(entry["cwd"]))
+            if entry.get("pipeline_registered") and entry.get("project_dir") and entry.get("cwd"):
+                try:
+                    process_name = str(Path(entry["cwd"]).relative_to(entry["project_dir"]))
+                    pipeline_bridge.set_process_status(
+                        Path(entry["project_dir"]), process_name, "Running")
+                except (ValueError, pipeline_bridge.PipelineBridgeError):
+                    pass
+            return self._update_persisted_only(
+                run_id, status=STATUS_RUNNING, ended_at=None, exit_code=None)
+        if run.status not in RESUMABLE_STATUSES:
+            raise ValueError(f"status must be one of {sorted(RESUMABLE_STATUSES)} to resume")
+        self._delete_pipeline_control_files(Path(run.cwd))
+        run.status = STATUS_RUNNING
+        run.ended_at = None
+        run.exit_code = None
+        self._persist(run)
+        await asyncio.to_thread(self._mark_pipeline_running, run)
+        await run.broadcast({"type": "status", "status": run.status, "exit_code": run.exit_code})
+        return run.to_summary()
+
+    @staticmethod
+    def _delete_pipeline_control_files(job_dir: Path) -> None:
+        """Same files pipeline_control_delete_exit_files() removes at the
+        start of a real RELION run -- see resume_run's own docstring for
+        why stale ones matter here."""
+        for name in (
+            "RELION_JOB_ABORT_NOW", "RELION_JOB_EXIT_SUCCESS",
+            "RELION_JOB_EXIT_FAILURE", "RELION_JOB_EXIT_ABORTED",
+        ):
+            try:
+                (job_dir / name).unlink(missing_ok=True)
+            except OSError:
+                pass
 
     def delete_run(self, run_id: str, remove_files: bool) -> tuple[bool, str]:
         """Real RELION 'Delete' job action. Always removes the run from

--- a/backend/main.py
+++ b/backend/main.py
@@ -426,6 +426,14 @@ async def start_run(req: StartRunRequest):
             run = await run_manager.start_custom_job(
                 req.internal_name, display_name, factory,
                 field_values=values, overwrite_run_id=req.overwrite_run_id,
+                # The picking jobs (Manualpick/TomoManualPick) only validate
+                # their inputs here -- the real work is picking, done
+                # afterward against this job's own directory via the Picker
+                # button, not by this coroutine -- so a successful return
+                # shouldn't complete the run. See start_custom_job's own
+                # stays_running docstring; the "Done" button (set_status)
+                # is what actually finishes it.
+                stays_running=CUSTOM_JOB_DEFINITIONS[req.internal_name].get("is_picker", False),
             )
         except ValueError as exc:
             raise HTTPException(status_code=409, detail=str(exc))
@@ -485,6 +493,34 @@ async def abort_run(run_id: str):
     return {"ok": True}
 
 
+@app.post("/api/runs/{run_id}/resume")
+async def resume_run(run_id: str):
+    """The picking jobs' "Continue" toolbar action -- see
+    JobRunManager.resume_run's own docstring. Restricted to Manualpick/
+    TomoManualPick here (not exposed generically): resuming a finished
+    subprocess/compute job back to "running" has no real meaning -- there
+    is no process left to have stopped."""
+    _reject_relion_run(run_id, "resumed")
+    run = run_manager.get(run_id)
+    internal_name = run.internal_name if run else None
+    if internal_name is None:
+        history = project_manager.load_history(run_manager.project_dir)
+        entry = next((h for h in history if h.get("run_id") == run_id), None)
+        internal_name = entry.get("internal_name") if entry else None
+    if internal_name is None or not CUSTOM_JOB_DEFINITIONS.get(internal_name, {}).get("is_picker"):
+        raise HTTPException(
+            status_code=400,
+            detail="Only a manual-picking job (Manualpick/TomoManualPick) can be resumed.",
+        )
+    try:
+        updated = await run_manager.resume_run(run_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    if updated is None:
+        raise HTTPException(status_code=404, detail="Unknown run_id")
+    return updated
+
+
 class RunUpdateRequest(BaseModel):
     alias: str | None = None
     note: str | None = None
@@ -492,7 +528,7 @@ class RunUpdateRequest(BaseModel):
 
 
 @app.patch("/api/runs/{run_id}")
-def update_run(run_id: str, req: RunUpdateRequest):
+async def update_run(run_id: str, req: RunUpdateRequest):
     """Command Center 'Alias' / 'Edit Note' / 'Mark as finished'/'Mark as
     failed' actions, combined into one endpoint since they're all small,
     independent metadata edits. Any combination of fields may be given in
@@ -526,7 +562,7 @@ def update_run(run_id: str, req: RunUpdateRequest):
             raise HTTPException(status_code=404, detail="Unknown run_id")
     if req.status is not None:
         try:
-            updated = run_manager.set_status(run_id, req.status)
+            updated = await run_manager.set_status(run_id, req.status)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc))
         if updated is None:

--- a/backend/manual_pick.py
+++ b/backend/manual_pick.py
@@ -220,6 +220,34 @@ def load_spa_picks(project_dir: Path, job_dir: Path, mic_path: str) -> list[dict
     ]
 
 
+def clear_spa_picks(job_dir: Path) -> int:
+    """Delete every pick this job has saved -- the job-level list
+    (manualpick.star) and every per-micrograph coordinate file it points
+    at. Called at the start of an Overwrite (see custom_jobs.run_manual_
+    pick): real RELION's own "Overwrite" job action re-runs into the SAME
+    directory (gui_mainwindow.cpp's cb_toggle_overwrite_continue), which
+    for a batch job means its outputs get regenerated from scratch anyway;
+    for a picking job, which has no batch step to regenerate anything, the
+    equivalent is clearing the slate explicitly. A fresh (never-run) job's
+    directory has nothing to clear, so this is a safe no-op there -- no
+    separate "is this actually an overwrite" flag needed. Returns how many
+    files were removed, for the run's own summary line.
+
+    "Continue" (job_runner.JobRunManager.resume_run) is the other, non
+    -destructive way back into a picking session -- it does NOT call this.
+    """
+    job_dir = Path(job_dir)
+    removed = 0
+    job_star = job_dir / SPA_JOB_STAR_NAME
+    if job_star.is_file():
+        job_star.unlink()
+        removed += 1
+    for coord_file in job_dir.glob(f"*{SPA_COORD_FILENAME_SUFFIX}"):
+        coord_file.unlink()
+        removed += 1
+    return removed
+
+
 # --------------------------------------------------------------------------
 # Tomography (3D tomograms)
 # --------------------------------------------------------------------------
@@ -361,3 +389,23 @@ def load_tomo_picks(project_dir: Path, job_dir: Path, tomo_name: str) -> list[di
          "z": float(row["rlnCoordinateZ"]), "class": 1}
         for _, row in df.iterrows()
     ]
+
+
+def clear_tomo_picks(job_dir: Path) -> int:
+    """Tomography counterpart of clear_spa_picks above -- every per-tomogram
+    annotation file plus the combined particles.star/optimisation_set.star.
+    Same "Overwrite means start clean" reasoning; see that function's own
+    docstring."""
+    job_dir = Path(job_dir)
+    removed = 0
+    for name in (TOMO_PARTICLES_STAR_NAME, TOMO_OPTSET_STAR_NAME):
+        p = job_dir / name
+        if p.is_file():
+            p.unlink()
+            removed += 1
+    ann_dir = job_dir / TOMO_ANNOTATIONS_DIRNAME
+    if ann_dir.is_dir():
+        for ann_file in ann_dir.glob("*_particles.star"):
+            ann_file.unlink()
+            removed += 1
+    return removed

--- a/backend/pipeline_bridge.py
+++ b/backend/pipeline_bridge.py
@@ -2,14 +2,16 @@
 pipeline_bridge.py — registering RELION-US's jobs in RELION's own pipeline, so
 the two GUIs can be used on the same project interchangeably.
 
-**Nothing here writes `default_pipeline.star`.** Every change to it goes through
-RELION's own `relion_pipeliner` binary. That is not squeamishness — the file is
-five linked tables (general, processes, nodes, input edges, output edges), the
-node graph is computed by each job's own `getCommands<Job>Job()` C++, and access
-is guarded by a `.relion_lock/` mutex directory that RELION's GUI holds while it
-is open. Reimplementing any of that in Python would be a new source of truth
-for a file this app is only a guest in, and the failure mode is a corrupted
-project rather than an error message.
+**Almost nothing here writes `default_pipeline.star` directly.** Every change
+to it goes through RELION's own `relion_pipeliner` binary, with ONE narrow,
+deliberate exception (set_process_status, below). That is not squeamishness —
+the file is five linked tables (general, processes, nodes, input edges,
+output edges), the node graph is computed by each job's own
+`getCommands<Job>Job()` C++, and access is guarded by a `.relion_lock/` mutex
+directory that RELION's GUI holds while it is open. Reimplementing any of
+that in Python would be a new source of truth for a file this app is only a
+guest in, and the failure mode is a corrupted project rather than an error
+message.
 
 The relevant entry point, from `src/apps/pipeliner.cpp`:
 
@@ -31,22 +33,51 @@ therefore does all of this itself:
 precisely the division of labour we want: RELION owns the bookkeeping, RELION-US
 runs the command the user approved.
 
-Completion is RELION's mechanism too. `prepareFinalCommand` appends
-`--pipeline_control <jobdir>/` to every `relion_` command; the program then
-writes `RELION_JOB_EXIT_SUCCESS` / `_FAILURE` / `_ABORTED` into that directory
-when it ends (`src/pipeline_control.h`), and
+**Completion used to be documented as "RELION's mechanism too" here — that
+turned out to be untested and wrong.** `prepareFinalCommand` appends
+`--pipeline_control <jobdir>/` to every `relion_` command; the program writes
+`RELION_JOB_EXIT_SUCCESS` / `_FAILURE` / `_ABORTED` into that directory when
+it ends (`src/pipeline_control.h`), and
 
     relion_pipeliner --check_job_completion
 
-flips the pipeline's status for any Running process whose exit file has
-appeared. RELION-US appends the same flag and calls the same command, so a job
-run here reaches "Succeeded" in RELION's GUI by RELION's own route.
+reads those files back -- but only for a process whose STATUS IS ALREADY
+"Running" (`PipeLine::checkProcessCompletion`, `src/pipeliner.cpp`: "Only
+check running processes for file existence"). Confirmed live against the
+real 5.0.1 binary: registering a job (always "Scheduled" -- there is no
+`--addJobFromStar` variant that adds it as "Running") and then touching its
+exit-success file does NOT flip its status; `--check_job_completion` silently
+ignores it. And there is no other CLI path to "Running" that doesn't mean
+actually re-executing the job's real command (`--RunJobs` -- wrong for
+RELION-US, which already ran the real work itself; for the in-browser
+picking jobs specifically, that "real command" is a desktop GUI that can't
+run headlessly, which is the whole reason they exist). So every job
+RELION-US ever registered was permanently stuck showing "Scheduled" in
+RELION's own GUI, regardless of whether it had actually finished.
+
+`set_process_status()` is the fix: a narrow, surgical exception that writes
+directly to the `pipeline_processes` block's status column for one process,
+under the SAME `.relion_lock` mutex `relion_pipeliner` itself takes. It only
+ever changes one whitespace-delimited token on one line -- never node/edge
+tables, never anything `relion_pipeliner`'s own command-building or graph
+logic is the authority for -- so this cannot desync the pipeline the way
+reimplementing registration or node computation would. Called once to mark
+"Running" right when real work starts (job_runner.py), after which
+`--check_job_completion` (still called exactly as before) can actually do
+its job and promote Running -> Succeeded/Failed/Aborted through RELION's own
+route, or in one flow (picking jobs, which stay "Running" indefinitely) is
+called directly to set the terminal status when the user clicks Done. This
+is safe against RELION-US's own concurrent operations (the lock), but NOT a
+substitute for closing any native RELION GUI that already has the project
+open -- a live GUI process holds its own in-memory copy of the pipeline this
+write can't coordinate with; see the app's startup warning.
 """
 from __future__ import annotations
 
 import shutil
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 from typing import Any, Optional
 
@@ -171,6 +202,138 @@ def is_locked(project_dir: Path) -> bool:
     pipeline operation hang for a minute and then fail.
     """
     return (Path(project_dir) / LOCK_DIRNAME).is_dir()
+
+
+# --------------------------------------------------------------------------
+# The one direct write -- see module docstring for why this exists and what
+# it deliberately does NOT touch.
+# --------------------------------------------------------------------------
+
+# The five real RELION status labels (pipeline_jobs.h's procstatus_type2label)
+# -- kept here rather than re-deriving from project_manager.RELION_STATUS_MAP,
+# which maps the OTHER direction (RELION's labels -> this app's own status
+# vocabulary) and is lossy for that purpose (several RELION labels can map to
+# one app status).
+RELION_STATUS_LABELS = frozenset({"Running", "Scheduled", "Succeeded", "Failed", "Aborted"})
+
+# RELION waits 3s a try, 20 tries (~60s) before giving up on the lock -- see
+# LOCK_DIRNAME's own comment. Matched here so a concurrent relion_pipeliner
+# invocation (this app's own registration/completion-check calls) gets the
+# same grace period rather than losing a race to an artificially short wait.
+_LOCK_TIMEOUT_SECONDS = 60.0
+_LOCK_POLL_SECONDS = 0.2
+
+
+def _acquire_pipeline_lock(project_dir: Path, timeout: Optional[float] = None) -> None:
+    """mkdir is atomic -- the same mutex idiom PipeLine::read/write use
+    against LOCK_DIRNAME. Raises PipelineBridgeError on timeout, the same
+    way a real relion_pipeliner invocation eventually gives up and errors
+    (see _run_pipeliner's own timeout).
+
+    timeout defaults to the module-level _LOCK_TIMEOUT_SECONDS, looked up
+    here (at call time) rather than as this parameter's own default value,
+    so a test monkeypatching that module attribute actually takes effect --
+    a default argument's value is bound once, at function-definition time,
+    and would otherwise ignore the patch entirely.
+    """
+    if timeout is None:
+        timeout = _LOCK_TIMEOUT_SECONDS
+    lock_dir = Path(project_dir) / LOCK_DIRNAME
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            lock_dir.mkdir()
+            return
+        except FileExistsError:
+            if time.monotonic() > deadline:
+                raise PipelineBridgeError(
+                    f"Could not acquire the pipeline lock ({lock_dir}) within "
+                    f"{timeout:.0f}s -- another process (this app, or a RELION "
+                    f"GUI) is using the pipeline right now. If a RELION GUI "
+                    f"crashed, a stale {LOCK_DIRNAME}/ directory may need to "
+                    f"be removed by hand."
+                )
+            time.sleep(_LOCK_POLL_SECONDS)
+
+
+def _release_pipeline_lock(project_dir: Path) -> None:
+    try:
+        (Path(project_dir) / LOCK_DIRNAME).rmdir()
+    except OSError:
+        pass
+
+
+def _rewrite_process_status(text: str, process_name: str, status_label: str) -> tuple[str, bool]:
+    """Replace the status column of ONE row in the `pipeline_processes`
+    loop_ block, byte-for-byte everywhere else -- see module docstring for
+    why this is a text-level edit rather than a full STAR parse/rewrite
+    (smaller, more predictable blast radius: this cannot touch a table it
+    doesn't understand, because it never looks at one).
+
+    A `pipeline_processes` data row is exactly 4 whitespace-separated
+    tokens (name, alias, type label, status -- confirmed against real
+    relion_pipeliner output); every other block's rows have a different
+    column count, so scoping to `data_pipeline_processes` specifically
+    (rather than just "4 tokens, ends in a known status word") is
+    extra insurance, not the only thing preventing a wrong-block match.
+    """
+    target = process_name.rstrip("/")
+    lines = text.split("\n")
+    in_processes_block = False
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("data_"):
+            in_processes_block = stripped == "data_pipeline_processes"
+            continue
+        if not in_processes_block or not stripped or stripped.startswith(("_", "loop_", "#")):
+            continue
+        parts = stripped.split()
+        if len(parts) != 4 or parts[0].rstrip("/") != target:
+            continue
+        old_status = parts[3]
+        idx = line.rfind(old_status)
+        lines[i] = line[:idx] + status_label + line[idx + len(old_status):]
+        return "\n".join(lines), True
+    return text, False
+
+
+def set_process_status(project_dir: Path, process_name: str, status_label: str) -> bool:
+    """Directly set one process's status in RELION's own
+    default_pipeline.star -- see module docstring for why this exists (in
+    short: relion_pipeliner's CLI has no way to mark a job "Running" short
+    of actually re-executing its real command, and --check_job_completion
+    only ever promotes a process already marked "Running").
+
+    process_name: RELION's own process name, project-relative, e.g.
+    "MotionCorr/job007" (trailing slash optional -- normalized either way).
+    status_label: one of RELION_STATUS_LABELS.
+
+    Returns False (not an error) if default_pipeline.star doesn't exist or
+    the process isn't found in it -- nothing to update, not a failure this
+    app should block a real job over. Raises PipelineBridgeError if the
+    lock can't be acquired (see _acquire_pipeline_lock) or the file can't be
+    read/written.
+    """
+    if status_label not in RELION_STATUS_LABELS:
+        raise ValueError(f"status_label must be one of {sorted(RELION_STATUS_LABELS)}")
+    star_path = Path(project_dir) / "default_pipeline.star"
+    if not star_path.exists():
+        return False
+    _acquire_pipeline_lock(project_dir)
+    try:
+        try:
+            text = star_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise PipelineBridgeError(f"could not read {star_path}: {exc}") from exc
+        new_text, changed = _rewrite_process_status(text, process_name, status_label)
+        if changed:
+            try:
+                star_path.write_text(new_text, encoding="utf-8")
+            except OSError as exc:
+                raise PipelineBridgeError(f"could not write {star_path}: {exc}") from exc
+        return changed
+    finally:
+        _release_pipeline_lock(project_dir)
 
 
 # --------------------------------------------------------------------------

--- a/backend/tests/fake_relion_pipeliner.py
+++ b/backend/tests/fake_relion_pipeliner.py
@@ -116,7 +116,17 @@ def check_job_completion() -> int:
     counter, processes = read_pipeline()
     changed = False
     for p in processes:
-        if p[3] not in ("Running", "Scheduled"):
+        # Only "Running" -- confirmed against the real 5.0.1 binary
+        # (PipeLine::checkProcessCompletion, src/pipeliner.cpp: "Only check
+        # running processes for file existence"). A job added via
+        # --addJobFromStar is always "Scheduled" and STAYS that way through
+        # this call, no matter what exit files exist in its directory --
+        # this fake used to accept "Scheduled" here too, which is exactly
+        # backwards and let a real bug (jobs stuck "Scheduled" forever)
+        # hide behind a passing test suite. See pipeline_bridge.
+        # set_process_status for the direct-write fix that's actually
+        # needed to reach "Running" at all.
+        if p[3] != "Running":
             continue
         d = Path(p[0].rstrip("/"))
         for fname, status in EXIT_FILES.items():

--- a/backend/tests/test_custom_jobs.py
+++ b/backend/tests/test_custom_jobs.py
@@ -186,4 +186,222 @@ def test_manualpick_job_registers_in_relions_pipeline_and_gets_an_exit_marker(sy
     assert job_dir.parent.name == "ManualPick"
     assert (job_dir / "RELION_JOB_EXIT_SUCCESS").is_file()
     pipeline = project_manager.read_relion_pipeline(project)
-    assert any(p["name"] == f"ManualPick/{job_dir.name}" for p in pipeline["processes"])
+    proc = next(p for p in pipeline["processes"] if p["name"] == f"ManualPick/{job_dir.name}")
+    # Not just "the marker file exists" -- RELION's own pipeline must
+    # actually have reached "Succeeded", not stayed stuck "Scheduled" (the
+    # bug pipeline_bridge.set_process_status exists to fix: relion_pipeliner
+    # --check_job_completion only ever promotes a process already marked
+    # "Running", which nothing got here without the direct-write fix).
+    assert proc["status_label"] == "Succeeded"
+
+
+def test_stays_running_job_reaches_running_not_completed(synced_project):
+    """Manualpick/TomoManualPick (main.py wires stays_running=is_picker) --
+    a successful validation coroutine must leave the run at "running", not
+    auto-complete it. The real picking happens afterward, out of band, via
+    the Picker button; "Done" (set_status) is what actually finishes it."""
+    project = synced_project
+    (project / "mics.star").write_text(
+        "\ndata_micrographs\n\nloop_\n_rlnMicrographName #1\na.mrc\n"
+    )
+    manager = JobRunManager(project)
+    values = {"fn_in": "mics.star"}
+
+    async def go():
+        async def factory(job_dir):
+            return await custom_jobs.run_manual_pick(project, values, job_dir)
+        run = await manager.start_custom_job(
+            "Manualpick", "Manual Picking", factory, field_values=values, stays_running=True)
+        for _ in range(200):
+            await asyncio.sleep(0.02)
+            if run.status != "pending":
+                break
+        return run
+
+    run = asyncio.run(go())
+    assert run.status == "running"
+    assert run.ended_at is None
+    job_dir = Path(run.cwd)
+    assert not (job_dir / "RELION_JOB_EXIT_SUCCESS").exists()  # not finished yet
+    pipeline = project_manager.read_relion_pipeline(project)
+    proc = next(p for p in pipeline["processes"] if p["name"] == f"ManualPick/{job_dir.name}")
+    # Marked Running in RELION's own pipeline even though our own coroutine
+    # already returned -- see JobRunManager._mark_pipeline_running.
+    assert proc["status_label"] == "Running"
+
+
+def test_done_button_finishes_a_stays_running_job(synced_project):
+    """set_status("completed") on a still-"running" picking job is the
+    "Done" button: it must do the FULL completion handshake (exit marker +
+    --check_job_completion), not just flip run.status locally, or RELION's
+    own GUI would stay stuck on "Running" forever."""
+    project = synced_project
+    (project / "mics.star").write_text(
+        "\ndata_micrographs\n\nloop_\n_rlnMicrographName #1\na.mrc\n"
+    )
+    manager = JobRunManager(project)
+    values = {"fn_in": "mics.star"}
+
+    async def go():
+        async def factory(job_dir):
+            return await custom_jobs.run_manual_pick(project, values, job_dir)
+        run = await manager.start_custom_job(
+            "Manualpick", "Manual Picking", factory, field_values=values, stays_running=True)
+        for _ in range(200):
+            await asyncio.sleep(0.02)
+            if run.status != "pending":
+                break
+        assert run.status == "running"
+        updated = await manager.set_status(run.run_id, "completed")
+        return run, updated
+
+    run, updated = asyncio.run(go())
+    assert run.status == "completed"
+    assert run.ended_at is not None
+    assert updated["status"] == "completed"
+    job_dir = Path(run.cwd)
+    assert (job_dir / "RELION_JOB_EXIT_SUCCESS").is_file()
+    pipeline = project_manager.read_relion_pipeline(project)
+    proc = next(p for p in pipeline["processes"] if p["name"] == f"ManualPick/{job_dir.name}")
+    assert proc["status_label"] == "Succeeded"
+
+
+def test_resume_run_returns_to_running_without_touching_picks(synced_project):
+    """"Continue" -- job_runner.resume_run -- must be non-destructive: the
+    picks already saved stay exactly as they are."""
+    project = synced_project
+    (project / "mics.star").write_text(
+        "\ndata_micrographs\n\nloop_\n_rlnMicrographName #1\na.mrc\n"
+    )
+    manager = JobRunManager(project)
+    values = {"fn_in": "mics.star"}
+
+    async def go():
+        async def factory(job_dir):
+            return await custom_jobs.run_manual_pick(project, values, job_dir)
+        run = await manager.start_custom_job(
+            "Manualpick", "Manual Picking", factory, field_values=values, stays_running=True)
+        for _ in range(200):
+            await asyncio.sleep(0.02)
+            if run.status != "pending":
+                break
+        import manual_pick
+        manual_pick.save_spa_picks(project, Path(run.cwd), "a.mrc", [{"x": 1.0, "y": 2.0}])
+        await manager.set_status(run.run_id, "completed")
+        assert run.status == "completed"
+        updated = await manager.resume_run(run.run_id)
+        return run, updated
+
+    run, updated = asyncio.run(go())
+    assert run.status == "running"
+    assert run.ended_at is None
+    assert updated["status"] == "running"
+    import manual_pick
+    assert manual_pick.load_spa_picks(project, Path(run.cwd), "a.mrc") == [{"x": 1.0, "y": 2.0, "class": 1}]
+    pipeline = project_manager.read_relion_pipeline(project)
+    proc = next(p for p in pipeline["processes"] if p["name"] == f"ManualPick/{Path(run.cwd).name}")
+    assert proc["status_label"] == "Running"
+
+
+def test_resume_run_rejects_a_currently_running_job(synced_project):
+    project = synced_project
+    (project / "mics.star").write_text(
+        "\ndata_micrographs\n\nloop_\n_rlnMicrographName #1\na.mrc\n"
+    )
+    manager = JobRunManager(project)
+    values = {"fn_in": "mics.star"}
+
+    async def go():
+        async def factory(job_dir):
+            return await custom_jobs.run_manual_pick(project, values, job_dir)
+        run = await manager.start_custom_job(
+            "Manualpick", "Manual Picking", factory, field_values=values, stays_running=True)
+        for _ in range(200):
+            await asyncio.sleep(0.02)
+            if run.status != "pending":
+                break
+        assert run.status == "running"
+        with pytest.raises(ValueError, match="resume"):
+            await manager.resume_run(run.run_id)
+
+    asyncio.run(go())
+
+
+def test_overwrite_clears_prior_picks_and_resumes_running(synced_project):
+    """Overwrite is the destructive counterpart to Continue -- it must
+    genuinely clear existing picks (custom_jobs.run_manual_pick calls
+    manual_pick.clear_spa_picks at the top), not just reset run.status."""
+    project = synced_project
+    (project / "mics.star").write_text(
+        "\ndata_micrographs\n\nloop_\n_rlnMicrographName #1\na.mrc\n"
+    )
+    manager = JobRunManager(project)
+    values = {"fn_in": "mics.star"}
+
+    async def go():
+        async def factory(job_dir):
+            return await custom_jobs.run_manual_pick(project, values, job_dir)
+        run = await manager.start_custom_job(
+            "Manualpick", "Manual Picking", factory, field_values=values, stays_running=True)
+        for _ in range(200):
+            await asyncio.sleep(0.02)
+            if run.status != "pending":
+                break
+        import manual_pick
+        manual_pick.save_spa_picks(project, Path(run.cwd), "a.mrc", [{"x": 1.0, "y": 2.0}])
+        await manager.set_status(run.run_id, "completed")
+
+        overwritten = await manager.start_custom_job(
+            "Manualpick", "Manual Picking", factory, field_values=values,
+            overwrite_run_id=run.run_id, stays_running=True,
+        )
+        for _ in range(200):
+            await asyncio.sleep(0.02)
+            if overwritten.status != "pending":
+                break
+        return run, overwritten
+
+    run, overwritten = asyncio.run(go())
+    assert overwritten.run_id == run.run_id  # same slot
+    assert overwritten.status == "running"
+    import manual_pick
+    assert manual_pick.load_spa_picks(project, Path(overwritten.cwd), "a.mrc") == []
+
+
+def test_overwrite_works_directly_on_a_still_running_picking_session(synced_project):
+    """A picker's "running" status means "picking session open," not
+    "compute in progress" -- Overwrite must be usable straight from that
+    state without requiring Done first (found via browser verification:
+    _resolve_overwrite_target used to reject ANY running run, picker or
+    not)."""
+    project = synced_project
+    (project / "mics.star").write_text(
+        "\ndata_micrographs\n\nloop_\n_rlnMicrographName #1\na.mrc\n"
+    )
+    manager = JobRunManager(project)
+    values = {"fn_in": "mics.star"}
+
+    async def go():
+        async def factory(job_dir):
+            return await custom_jobs.run_manual_pick(project, values, job_dir)
+        run = await manager.start_custom_job(
+            "Manualpick", "Manual Picking", factory, field_values=values, stays_running=True)
+        for _ in range(200):
+            await asyncio.sleep(0.02)
+            if run.status != "pending":
+                break
+        assert run.status == "running"  # never touched Done/set_status
+
+        overwritten = await manager.start_custom_job(
+            "Manualpick", "Manual Picking", factory, field_values=values,
+            overwrite_run_id=run.run_id, stays_running=True,
+        )
+        for _ in range(200):
+            await asyncio.sleep(0.02)
+            if overwritten.status != "pending":
+                break
+        return run, overwritten
+
+    run, overwritten = asyncio.run(go())
+    assert overwritten.run_id == run.run_id
+    assert overwritten.status == "running"

--- a/backend/tests/test_manual_pick.py
+++ b/backend/tests/test_manual_pick.py
@@ -229,3 +229,46 @@ def test_load_tomo_picks_round_trips(tmp_path):
         project, job_dir, "TS_01", [{"x": 9.0, "y": 8.0, "z": 7.0}], "tomograms.star")
     loaded = manual_pick.load_tomo_picks(project, job_dir, "TS_01")
     assert loaded == [{"x": 9.0, "y": 8.0, "z": 7.0, "class": 1}]
+
+
+# --------------------------------------------------------------------------
+# clear_spa_picks / clear_tomo_picks -- what Overwrite calls (via
+# custom_jobs.run_manual_pick/run_tomo_manual_pick) to genuinely start
+# clean, as opposed to Continue (job_runner.resume_run), which touches
+# nothing on disk.
+# --------------------------------------------------------------------------
+
+
+def test_clear_spa_picks_removes_job_star_and_coord_files(tmp_path):
+    project = _spa_project(tmp_path)
+    job_dir = project / "ManualPick" / "job005"
+    manual_pick.save_spa_picks(
+        project, job_dir, "MotionCorr/job002/020/mic001.mrc", [{"x": 1.0, "y": 1.0}])
+    manual_pick.save_spa_picks(
+        project, job_dir, "MotionCorr/job002/021/mic001.mrc", [{"x": 2.0, "y": 2.0}])
+    assert manual_pick.clear_spa_picks(job_dir) == 3  # job-level star + 2 coord files
+    assert not (job_dir / "manualpick.star").exists()
+    assert list(job_dir.glob("*_manualpick.star")) == []
+
+
+def test_clear_spa_picks_on_a_fresh_job_dir_is_a_noop(tmp_path):
+    job_dir = tmp_path / "ManualPick" / "job001"
+    job_dir.mkdir(parents=True)
+    assert manual_pick.clear_spa_picks(job_dir) == 0
+
+
+def test_clear_tomo_picks_removes_everything(tmp_path):
+    project = _tomo_project(tmp_path)
+    job_dir = project / "Picks" / "job006"
+    manual_pick.save_tomo_picks(
+        project, job_dir, "TS_01", [{"x": 1.0, "y": 1.0, "z": 1.0}], "tomograms.star")
+    assert manual_pick.clear_tomo_picks(job_dir) == 3  # annotation + particles + optimisation_set
+    assert not (job_dir / "particles.star").exists()
+    assert not (job_dir / "optimisation_set.star").exists()
+    assert list((job_dir / "annotations").glob("*_particles.star")) == []
+
+
+def test_clear_tomo_picks_on_a_fresh_job_dir_is_a_noop(tmp_path):
+    job_dir = tmp_path / "Picks" / "job001"
+    job_dir.mkdir(parents=True)
+    assert manual_pick.clear_tomo_picks(job_dir) == 0

--- a/backend/tests/test_pipeline_bridge.py
+++ b/backend/tests/test_pipeline_bridge.py
@@ -290,6 +290,12 @@ def test_missing_pipeliner_raises_with_an_actionable_message(tmp_path, monkeypat
 
 def test_completion_moves_the_job_to_succeeded_in_relions_record(project):
     out = pipeline_bridge.register_job(project, "relion.class2d", {})
+    # --check_job_completion only ever promotes a process already marked
+    # "Running" (confirmed against the real 5.0.1 binary -- see
+    # set_process_status's own module-docstring section) -- a fresh
+    # registration is always "Scheduled", so this step is required, not
+    # optional set-dressing.
+    assert pipeline_bridge.set_process_status(project, out["process_name"], "Running") is True
     # what a relion_ program writes when it ends, because of --pipeline_control
     (project / out["process_name"] / "RELION_JOB_EXIT_SUCCESS").write_text("")
     assert pipeline_bridge.check_job_completion(project) is True
@@ -299,10 +305,23 @@ def test_completion_moves_the_job_to_succeeded_in_relions_record(project):
 
 def test_a_failed_job_reaches_relion_as_failed(project):
     out = pipeline_bridge.register_job(project, "relion.class2d", {})
+    pipeline_bridge.set_process_status(project, out["process_name"], "Running")
     (project / out["process_name"] / "RELION_JOB_EXIT_FAILURE").write_text("")
     pipeline_bridge.check_job_completion(project)
     procs = project_manager.read_relion_pipeline(project)["processes"]
     assert procs[0]["status_label"] == "Failed"
+
+
+def test_check_job_completion_ignores_a_still_scheduled_job(project):
+    """The bug set_process_status exists to fix, pinned directly: a
+    registered-but-never-marked-Running job must NOT be promoted by
+    --check_job_completion just because its exit file exists -- confirmed
+    against the real binary (see pipeline_bridge.py's module docstring)."""
+    out = pipeline_bridge.register_job(project, "relion.class2d", {})
+    (project / out["process_name"] / "RELION_JOB_EXIT_SUCCESS").write_text("")
+    assert pipeline_bridge.check_job_completion(project) is True  # the CALL succeeds...
+    procs = project_manager.read_relion_pipeline(project)["processes"]
+    assert procs[0]["status_label"] == "Scheduled"  # ...but nothing was actually promoted
 
 
 def test_pipeline_control_flag_is_appended_to_relion_commands():
@@ -669,3 +688,114 @@ def test_overwrite_leaves_command_alone_when_sync_is_off(project):
 
     second = asyncio.run(go())
     assert "--pipeline_control" not in second.command
+
+
+# --------------------------------------------------------------------------
+# set_process_status -- the one deliberate exception to "never hand-write
+# default_pipeline.star" (see pipeline_bridge.py's module docstring for why
+# it exists: --check_job_completion only ever promotes a process already
+# marked "Running", and nothing in relion_pipeliner's CLI can mark one
+# Running without actually re-executing its real command).
+# --------------------------------------------------------------------------
+
+_REAL_PROCESSES_BLOCK = """
+# version 50001
+
+data_pipeline_general
+
+_rlnPipeLineJobCounter                       2
+ 
+
+# version 50001
+
+data_pipeline_processes
+
+loop_ 
+_rlnPipeLineProcessName #1 
+_rlnPipeLineProcessAlias #2 
+_rlnPipeLineProcessTypeLabel #3 
+_rlnPipeLineProcessStatusLabel #4 
+Import/job000/       None relion.import.movies  Scheduled 
+ManualPick/job001/       None relion.manualpick  Running 
+ 
+
+# version 50001
+
+data_pipeline_nodes
+
+loop_ 
+_rlnPipeLineNodeName #1 
+_rlnPipeLineNodeTypeLabel #2 
+_rlnPipeLineNodeTypeLabelDepth #3 
+Import/job000/movies.star MicrographMovieGroupMetadata.star.relion            1 
+"""
+
+
+def test_rewrite_process_status_changes_only_the_target_row():
+    new_text, changed = pipeline_bridge._rewrite_process_status(
+        _REAL_PROCESSES_BLOCK, "Import/job000", "Running")
+    assert changed is True
+    assert "Import/job000/       None relion.import.movies  Running" in new_text
+    # Untouched: the OTHER process's row, and every other block.
+    assert "ManualPick/job001/       None relion.manualpick  Running" in new_text
+    assert "Import/job000/movies.star MicrographMovieGroupMetadata.star.relion            1" in new_text
+    assert "_rlnPipeLineJobCounter                       2" in new_text
+
+
+def test_rewrite_process_status_normalizes_trailing_slash():
+    """Callers may pass "Import/job000" or "Import/job000/" -- both must
+    match the file's own "Import/job000/" row."""
+    new_text, changed = pipeline_bridge._rewrite_process_status(
+        _REAL_PROCESSES_BLOCK, "Import/job000/", "Failed")
+    assert changed is True
+    assert "Import/job000/       None relion.import.movies  Failed" in new_text
+
+
+def test_rewrite_process_status_unknown_process_is_a_noop():
+    new_text, changed = pipeline_bridge._rewrite_process_status(
+        _REAL_PROCESSES_BLOCK, "Import/job999", "Running")
+    assert changed is False
+    assert new_text == _REAL_PROCESSES_BLOCK
+
+
+def test_rewrite_process_status_never_touches_the_nodes_block():
+    """A node row has 3 tokens (name, type label, depth) -- a node whose
+    name happened to end in a status-like word must not be mistaken for a
+    processes row."""
+    text = _REAL_PROCESSES_BLOCK.replace(
+        "Import/job000/movies.star MicrographMovieGroupMetadata.star.relion            1",
+        "Import/job000/Running MicrographMovieGroupMetadata.star.relion            1",
+    )
+    new_text, changed = pipeline_bridge._rewrite_process_status(text, "Import/job000/Running", "Failed")
+    assert changed is False
+    assert "Import/job000/Running MicrographMovieGroupMetadata.star.relion            1" in new_text
+
+
+def test_set_process_status_end_to_end(tmp_path):
+    (tmp_path / "default_pipeline.star").write_text(_REAL_PROCESSES_BLOCK)
+    assert pipeline_bridge.set_process_status(tmp_path, "Import/job000", "Running") is True
+    text = (tmp_path / "default_pipeline.star").read_text()
+    assert "Import/job000/       None relion.import.movies  Running" in text
+    # The lock is taken and released, not left behind.
+    assert not (tmp_path / pipeline_bridge.LOCK_DIRNAME).exists()
+
+
+def test_set_process_status_no_pipeline_file_returns_false(tmp_path):
+    assert pipeline_bridge.set_process_status(tmp_path, "Import/job000", "Running") is False
+
+
+def test_set_process_status_rejects_an_unknown_label(tmp_path):
+    (tmp_path / "default_pipeline.star").write_text(_REAL_PROCESSES_BLOCK)
+    with pytest.raises(ValueError):
+        pipeline_bridge.set_process_status(tmp_path, "Import/job000", "InProgress")
+
+
+def test_set_process_status_times_out_on_a_held_lock(tmp_path, monkeypatch):
+    (tmp_path / "default_pipeline.star").write_text(_REAL_PROCESSES_BLOCK)
+    (tmp_path / pipeline_bridge.LOCK_DIRNAME).mkdir()
+    monkeypatch.setattr(pipeline_bridge, "_LOCK_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(pipeline_bridge, "_LOCK_POLL_SECONDS", 0.01)
+    with pytest.raises(pipeline_bridge.PipelineBridgeError, match="lock"):
+        pipeline_bridge.set_process_status(tmp_path, "Import/job000", "Running")
+    # A lock this call didn't take must not be removed by it.
+    assert (tmp_path / pipeline_bridge.LOCK_DIRNAME).exists()

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -510,7 +510,8 @@ async function openJobPopup(internalName, displayName, existingRun, opts = {}) {
       <button class="btn" data-action="close" title="Close this window">✕ Close</button>
       <button class="btn" data-action="note" title="Edit note">📝 Note</button>
       ${def.is_picker ? '<button class="btn primary" data-action="picker" hidden title="Open the in-browser picker for this job — double-click to add a pick, right-click to delete one">🔍 Open Picker</button>' : ""}
-      <button class="btn" data-action="overwrite" hidden title="Re-run into this SAME output directory, overwriting its files (RELION's 'Overwrite' job action)">⟳ Overwrite</button>
+      ${def.is_picker ? '<button class="btn" data-action="continue-picking" hidden title="Resume this picking session — keeps every pick already saved">▶ Continue</button>' : ""}
+      <button class="btn" data-action="overwrite" hidden title="${def.is_picker ? "Start a NEW picking session in this same job — deletes every pick already saved here. Use Continue instead to keep them." : "Re-run into this SAME output directory, overwriting its files (RELION's 'Overwrite' job action)"}">⟳ Overwrite</button>
       <button class="btn" data-action="clone" hidden title="Open a new job of this type, pre-filled with these same settings — a fresh job with its own new number, not tied to this one">⎘ Clone</button>
       <button class="btn" data-action="abort" hidden title="Stop this running job">⏹ Abort</button>
       <button class="btn" data-action="mark-finished" hidden title="Manually mark as finished">✓ Mark Finished</button>
@@ -540,6 +541,7 @@ async function openJobPopup(internalName, displayName, existingRun, opts = {}) {
     <div class="command-row active" data-role="command-row">
       <div class="command-actions">
         <button class="btn primary" data-role="run-btn">Run</button>
+        ${def.is_picker ? '<button class="btn primary" data-role="done-btn" hidden title="Finish this picking session — marks the job complete, including in RELION\'s own pipeline">✓ Done</button>' : ""}
         <span class="status-line" data-role="status-line"></span>
       </div>
     </div>` : `
@@ -855,12 +857,24 @@ async function openJobPopup(internalName, displayName, existingRun, opts = {}) {
     }
   }
 
+  // Declared here (before refreshToolbarState, defined just below, which
+  // reads them) rather than down near the rest of the Run/live-status
+  // wiring where they're USED -- referencing a `const` before its own
+  // declaration line throws (temporal dead zone), the exact bug this app
+  // already hit once with progressSplitCleanup (see that variable's own
+  // comment): refreshToolbarState's first call (line ~946) happens well
+  // before the Run/Done wiring section further down would otherwise
+  // declare these.
+  const runBtn = body.querySelector('[data-role="run-btn"]');
+  const doneBtn = body.querySelector('[data-role="done-btn"]');
+
   // --- Job actions toolbar --------------------------------------------
   const toolbar = body.querySelector('[data-role="actions-toolbar"]');
   const jobNameDisplay = toolbar.querySelector('[data-role="job-name-display"]');
   const noteRow = body.querySelector('[data-role="note-row"]');
   const overwriteBtn = toolbar.querySelector('[data-action="overwrite"]');
   const pickerBtn = toolbar.querySelector('[data-action="picker"]');
+  const continueBtn = toolbar.querySelector('[data-action="continue-picking"]');
   const cloneBtn = toolbar.querySelector('[data-action="clone"]');
   const abortBtn = toolbar.querySelector('[data-action="abort"]');
   const markFinishedBtn = toolbar.querySelector('[data-action="mark-finished"]');
@@ -903,11 +917,24 @@ async function openJobPopup(internalName, displayName, existingRun, opts = {}) {
     // something untrue. Browsing its outputs and settings is fine.
     const fromRelion = hasRun && currentRun.source === "relion";
     jobNameDisplay.textContent = hasRun ? currentRun.job_name : displayName;
-    // Picking doesn't go through Overwrite/re-run semantics -- it's always
-    // available once the job exists (see custom_jobs.run_manual_pick's own
-    // docstring for why "completed" doesn't mean "done picking").
+    // Open Picker is always available once the job exists, regardless of
+    // status -- you can review/add picks whether the session is still
+    // "running" or already marked Done.
     if (pickerBtn) pickerBtn.hidden = !hasRun || fromRelion;
-    overwriteBtn.hidden = !hasRun || fromRelion || status === "running";
+    // Continue (resume "running" with existing picks kept -- job_runner.
+    // resume_run) only makes sense once a picking session has actually been
+    // marked Done/Failed; RESUMABLE_STATUSES on the backend is the same set.
+    if (continueBtn) {
+      continueBtn.hidden = !hasRun || fromRelion || !(status === "completed" || status === "failed");
+    }
+    // Overwrite blocks on "running" for a normal job (nothing sensible to
+    // re-run into while it's still going) -- NOT for a picking job, whose
+    // "running" is a steady, long-lived state with no real computation to
+    // collide with; Overwrite there means "abandon these picks and start a
+    // clean session in the same slot" (see custom_jobs.run_manual_pick),
+    // meaningful at any point.
+    const overwriteBlockedByStatus = status === "running" && !def.is_picker;
+    overwriteBtn.hidden = !hasRun || fromRelion || overwriteBlockedByStatus;
     // Clone never touches the job it's cloning FROM -- it only reads its
     // field_values and opens a fresh, separately-numbered job -- so unlike
     // Overwrite it's safe even for a RELION-native (read-only) job or one
@@ -923,6 +950,16 @@ async function openJobPopup(internalName, displayName, existingRun, opts = {}) {
       ? "Run in RELION itself — rename it there"
       : "Click to rename (RELION's 'Alias' job action)";
     outputsTabBtn.hidden = !hasRun;
+    // Run/Done (the bottom command-row) for a picking job: purely status
+    // -driven, so it stays correct through every path that can change
+    // currentRun.status -- a fresh Run, Continue, Done itself, Overwrite
+    // (which closes and reopens this popup with the new run already
+    // "running"), and a live "status" broadcast over the websocket (see
+    // connectWebSocket's onmessage, which calls this same function).
+    if (def.is_picker && runBtn) {
+      runBtn.style.display = hasRun ? "none" : "";
+      if (doneBtn) doneBtn.hidden = !hasRun || status !== "running";
+    }
     refreshProgressTabVisibility();
     refreshCtfQcTabVisibility();
     refreshNoteRow();
@@ -1035,6 +1072,25 @@ async function openJobPopup(internalName, displayName, existingRun, opts = {}) {
         return;
       }
       openVisualizer({ runId: currentRun.run_id, kind: def.picker_kind, sourcePath });
+    });
+  }
+
+  if (continueBtn) {
+    continueBtn.addEventListener("click", async () => {
+      if (!currentRun) return;
+      continueBtn.disabled = true;
+      try {
+        const updated = await api(`/api/runs/${currentRun.run_id}/resume`, { method: "POST" });
+        currentRun = updated;
+        statusLine.textContent = `Status: ${updated.status}`;
+        statusLine.className = statusLineClass(updated.status);
+        refreshToolbarState();
+        refreshCommandCenter();
+      } catch (err) {
+        errorDialog("Could not resume this picking session: " + err.message);
+      } finally {
+        continueBtn.disabled = false;
+      }
     });
   }
 
@@ -1694,7 +1750,6 @@ async function openJobPopup(internalName, displayName, existingRun, opts = {}) {
     ws.onerror = () => appendOutputLine("[websocket error]", true);
   }
 
-  const runBtn = body.querySelector('[data-role="run-btn"]');
   if (isReopen) {
     // Reopening history: don't offer a bare "Run" (that's what Overwrite,
     // in the toolbar, is for — re-running into the SAME job explicitly).
@@ -1736,6 +1791,35 @@ async function openJobPopup(internalName, displayName, existingRun, opts = {}) {
         // clicked into launching a second job and orphaning the first
         // job's websocket.
         runBtn.disabled = false;
+      }
+    });
+  }
+
+  if (doneBtn) {
+    doneBtn.addEventListener("click", async () => {
+      if (!currentRun) return;
+      const ok = await confirmDialog(
+        `Mark "${currentRun.job_name}" as finished? This ends the picking session -- `
+        + `you can still reopen the picker afterward, or use Continue to resume it.`,
+        { confirmLabel: "Done" }
+      );
+      if (!ok) return;
+      doneBtn.disabled = true;
+      try {
+        const updated = await api(`/api/runs/${currentRun.run_id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "completed" }),
+        });
+        currentRun = updated;
+        statusLine.textContent = `Status: ${updated.status}`;
+        statusLine.className = statusLineClass(updated.status);
+        refreshToolbarState();
+        refreshCommandCenter();
+      } catch (err) {
+        errorDialog("Could not mark this job done: " + err.message);
+      } finally {
+        doneBtn.disabled = false;
       }
     });
   }
@@ -2206,6 +2290,35 @@ async function refreshPipelineSync() {
     pipelineSyncState = { enabled: false, available: false, locked: false };
   }
   renderPipelineSyncButton();
+  await maybeWarnAboutOpenRelionGuis();
+}
+
+// RELION-US now writes directly into this project's default_pipeline.star
+// for one specific thing (a job's Running/Succeeded/Failed/Aborted status --
+// see backend/pipeline_bridge.py's set_process_status, the one deliberate
+// exception to "never hand-write that file", added because relion_pipeliner's
+// own CLI has no other way to reach those statuses without re-executing a
+// job's real command). That write takes the same .relion_lock mutex RELION's
+// own GUI does, which protects against two AUTOMATED writers colliding -- but
+// a native RELION GUI that already has this project open keeps its OWN
+// in-memory copy of the pipeline, edited and re-saved from THAT copy on its
+// own schedule, with no way for this app to coordinate with it. RELION-US is
+// meant to be usable as the sole day-to-day UI for a project with this on;
+// shown every time a project loads (not just once, ever) since leaving a
+// native GUI open is easy to forget about across sessions -- same reasoning
+// as this app's own "ask about the login password every startup" choice.
+function maybeWarnAboutOpenRelionGuis() {
+  if (!pipelineSyncState.enabled) return Promise.resolve();
+  return errorDialog(
+    "RELION sync is on for this project: RELION-US now updates this project's " +
+    "default_pipeline.star directly (job status only), not just through " +
+    "RELION's own relion_pipeliner.\n\n" +
+    "Close any native RELION GUI you have open on this project folder before " +
+    "continuing — a GUI that's already open keeps its own copy of the pipeline " +
+    "and won't see these updates, which risks corrupting the project if both " +
+    "write to it. Once closed, use RELION-US as the only interface to this " +
+    "project."
+  );
 }
 
 pipelineSyncBtn.addEventListener("click", async () => {
@@ -2214,9 +2327,14 @@ pipelineSyncBtn.addEventListener("click", async () => {
     const ok = await confirmDialog(
       "Record jobs run here in this project's default_pipeline.star?\n\n" +
       "RELION's own GUI will then list them, so you can switch between the two. " +
-      "RELION-US doesn't write that file itself — it asks RELION's own " +
-      "relion_pipeliner to add each job, which is what computes the job number, " +
-      "creates the directory and works out the input/output graph.\n\n" +
+      "RELION-US asks RELION's own relion_pipeliner to add each job and compute " +
+      "its node graph, but does directly update one thing itself: a job's " +
+      "Running/Succeeded/Failed status (relion_pipeliner's CLI has no other way " +
+      "to reach those without re-executing the job's real command).\n\n" +
+      "Close any native RELION GUI you have open on this project before turning " +
+      "this on, and use RELION-US as the only interface to it afterward — a GUI " +
+      "that's already open won't see these updates and risks corrupting the " +
+      "project if both write to it.\n\n" +
       "Jobs already run here are not added retrospectively.",
       { confirmLabel: "Turn on" }
     );
@@ -3992,3 +4110,4 @@ function currentTheme() {
 
 refreshProjectLabel();
 refreshCommandCenter();
+refreshPipelineSync();


### PR DESCRIPTION
relion_pipeliner's CLI can register a job (--addJobFromStar) but has no way
to move it out of "Scheduled" without re-executing its real command, so
every RELION-US job showed as permanently pending in native RELION's GUI.
pipeline_bridge.set_process_status() now does a narrow, lock-guarded,
text-level status write directly into default_pipeline.star to close that
gap, verified end-to-end against the real relion_pipeliner binary.

Manual picking jobs (Manualpick/TomoManualPick) get their own lifecycle on
top of this: Run starts a picking session that stays "running" until the
user is done (job_runner.stays_running), Done finishes it, Continue
resumes a finished session without touching existing picks, and Overwrite
clears picks and starts fresh in the same job slot -- including while a
picking session is still open, which required allow_running support in
_resolve_overwrite_target. A startup dialog warns to close any native
RELION GUI before using RELION-US as the project's sole interface.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>