### PR TITLE
Fix TomoImport's dose_rate always emitting --dose-per-tilt-image

### DIFF
--- a/backend/job_catalog.py
+++ b/backend/job_catalog.py
@@ -490,6 +490,14 @@ class FlagOverride:
     # in this table fires on checked, matching RELION's overwhelmingly more
     # common convention, so this defaults to False.
     negated: bool = False
+    # For the rarer case still: the SAME option's value needs to go out
+    # under a DIFFERENT flag when `condition` is false, rather than being
+    # omitted entirely -- e.g. TomoImport's dose_rate, which RELION emits as
+    # either `--dose-per-movie-frame <value>` or `--dose-per-tilt-image
+    # <value>` depending on a sibling checkbox (see its own entry below).
+    # Only meaningful when `condition` is set; `flag` above is used when the
+    # condition holds, this one when it doesn't.
+    flag_if_condition_false: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -589,10 +597,19 @@ DRAFT_OVERRIDES: dict[str, JobDraftOverride] = {
             "Cs": FlagOverride("--spherical-aberration"),
             "Q0": FlagOverride("--amplitude-contrast"),
             "optics_group_name": FlagOverride("--optics-group-name"),
-            # Default is per-tilt-image dose; toggling "Is dose rate per
-            # movie frame?" switches RELION to --dose-per-movie-frame (a
-            # branch a static map can't express -- noted in the field help).
-            "dose_rate": FlagOverride("--dose-per-tilt-image"),
+            # `if (dose_is_per_movie_frame) command += " --dose-per-movie-
+            # frame " + dose_rate; else command += " --dose-per-tilt-image "
+            # + dose_rate;` (~6506) -- the SAME dose_rate value goes out
+            # under one of two flag names depending on the sibling checkbox.
+            # Previously hardcoded to always emit --dose-per-tilt-image
+            # regardless of dose_is_per_movie_frame -- confirmed as a real
+            # bug (checking the box had no effect on the generated command)
+            # while auditing this for
+            # https://github.com/schiracha/RELION-US/issues/16.
+            "dose_rate": FlagOverride(
+                "--dose-per-tilt-image", condition="!dose_is_per_movie_frame",
+                flag_if_condition_false="--dose-per-movie-frame",
+            ),
             "prefix": FlagOverride("--prefix"),
             "mtf_file": FlagOverride("--mtf-file"),
             "flip_tiltseries_hand": FlagOverride("--invert-defocus-handedness"),
@@ -1246,6 +1263,18 @@ def draft_flag_is_negated(internal_name: str, option_key: str) -> bool:
     return bool(entry is not None and entry.negated)
 
 
+def draft_flag_if_condition_false_for(internal_name: str, option_key: str) -> Optional[str]:
+    """The alternate flag to use for this option's OWN value when its
+    `condition` evaluates False, instead of omitting the field -- or None if
+    there isn't one (the common case: condition false just means "don't
+    emit this flag at all"). See FlagOverride.flag_if_condition_false."""
+    override = _override(internal_name)
+    if override is None:
+        return None
+    entry = override.flags.get(option_key)
+    return entry.flag_if_condition_false if entry is not None else None
+
+
 def draft_program_override(internal_name: str) -> Optional[str]:
     """Verified program string for jobs whose extracted program_guess is
     wrong for the default configuration, else None. See
@@ -1298,3 +1327,28 @@ def draft_extra_output_args(internal_name: str, field_values: dict) -> list:
     if override is None or override.extra_output_args is None:
         return []
     return override.extra_output_args(field_values)
+
+
+# --------------------------------------------------------------------------
+# Form-presentation overrides -- separate from DRAFT_OVERRIDES above (which
+# only affects the generated command), these change how a field is offered
+# in the popup itself. Real RELION renders every entry below as a plain
+# Yes/No checkbox too; this isn't correcting real RELION, it's RELION-US
+# choosing a clearer widget for a field whose two states are easy to miss on
+# an unlabeled checkbox (unlike "Use parallel disc I/O?", where Yes/No reads
+# naturally, "Is dose rate per movie frame?" doesn't hint at what the OTHER
+# state means without reading the help text). The underlying value is still
+# a plain bool sent as field_values[key] -- job_registry/DRAFT_OVERRIDES
+# above need no changes to consume it; only frontend/app.js's renderField/
+# getFieldValue read this to pick a <select> over a checkbox.
+BOOLEAN_SELECT_LABELS: dict[tuple[str, str], tuple[str, str]] = {
+    # (internal_name, key): (label when False, label when True)
+    ("TomoImport", "dose_is_per_movie_frame"): ("Dose per tilt image", "Dose per movie frame"),
+}
+
+
+def boolean_select_labels(internal_name: str, option_key: str) -> Optional[tuple[str, str]]:
+    """(label_for_false, label_for_true) if this boolean field should be
+    offered as an explicit two-way dropdown instead of a checkbox, else
+    None (the common case -- a plain checkbox)."""
+    return BOOLEAN_SELECT_LABELS.get((internal_name, option_key))

--- a/backend/job_registry.py
+++ b/backend/job_registry.py
@@ -49,9 +49,11 @@ from job_catalog import (
     CUSTOM_JOBS,
     JOB_CATALOG,
     TOMO_VARIANT_OF,
+    boolean_select_labels,
     draft_extra_output_args,
     draft_flag_condition_for,
     draft_flag_for,
+    draft_flag_if_condition_false_for,
     draft_flag_is_negated,
     draft_value_for,
     has_draft_value_transform,
@@ -459,7 +461,14 @@ def _build_draft_command(
                     mapped_condition, field_values, options_by_key.keys()
                 )
                 if verdict is False:
-                    continue
+                    # Usually "don't emit this flag at all" -- but the rare
+                    # entry whose value needs a DIFFERENT flag on the false
+                    # branch (rather than being omitted), e.g. TomoImport's
+                    # dose_rate, names one via flag_if_condition_false.
+                    alt_flag = draft_flag_if_condition_false_for(base_name, key)
+                    if alt_flag is None:
+                        continue
+                    mapped = alt_flag
                 elif verdict is None:
                     unmapped.append(key)
                     continue
@@ -609,6 +618,16 @@ def build_job_definition(internal_name: str, output_subdir: str = "") -> dict:
     draft_command, unmapped = _build_draft_command(
         raw, default_values, internal_name, output_subdir
     )
+    # Copy (never mutate raw["options"] in place -- _load_raw() caches and
+    # shares it across every request) any option this specific menu entry
+    # wants offered as an explicit two-way dropdown instead of a checkbox --
+    # see job_catalog.boolean_select_labels's own docstring.
+    options = []
+    for opt in raw.get("options", []):
+        labels = boolean_select_labels(internal_name, opt["key"])
+        if labels:
+            opt = {**opt, "boolean_labels": {"false": labels[0], "true": labels[1]}}
+        options.append(opt)
 
     return {
         "internal_name": internal_name,
@@ -616,7 +635,7 @@ def build_job_definition(internal_name: str, output_subdir: str = "") -> dict:
         "display_name": display_name,
         "category": category,
         "description": description,
-        "options": raw.get("options", []),
+        "options": options,
         "standard_groups": standard_groups,
         "default_values": default_values,
         "program_guess": raw.get("program_guess"),

--- a/backend/tests/test_job_catalog.py
+++ b/backend/tests/test_job_catalog.py
@@ -22,6 +22,7 @@ from job_catalog import (
     draft_extra_output_args,
     draft_flag_condition_for,
     draft_flag_for,
+    draft_flag_if_condition_false_for,
     draft_flag_is_negated,
     draft_is_suppressed,
     draft_output_flag,
@@ -43,6 +44,7 @@ def test_unlisted_job_gets_every_accessors_default():
     assert draft_flag_for("Localres", "anything") is None
     assert draft_flag_condition_for("Localres", "anything") is None
     assert draft_flag_is_negated("Localres", "anything") is False
+    assert draft_flag_if_condition_false_for("Localres", "anything") is None
     assert draft_program_override("Localres") is None
     assert draft_is_suppressed("Localres", "anything") is False
     assert draft_output_flag("Localres") == "--o"
@@ -98,6 +100,18 @@ def test_conditioned_flag_override_exposes_its_condition():
 def test_negated_flag_override():
     assert draft_flag_for("Class2D", "do_parallel_discio") == "--no_parallel_disc_io"
     assert draft_flag_is_negated("Class2D", "do_parallel_discio") is True
+
+
+def test_flag_override_with_an_alternate_false_branch_flag():
+    # dose_rate goes out under one of two real flags depending on a sibling
+    # checkbox, rather than being simply present/absent -- see job_catalog's
+    # TomoImport entry and https://github.com/schiracha/RELION-US/issues/16.
+    assert draft_flag_for("TomoImport", "dose_rate") == "--dose-per-tilt-image"
+    assert draft_flag_condition_for("TomoImport", "dose_rate") == "!dose_is_per_movie_frame"
+    assert draft_flag_if_condition_false_for("TomoImport", "dose_rate") == "--dose-per-movie-frame"
+    # A field with only the common (no alternate) shape still answers None,
+    # not a KeyError or an empty string.
+    assert draft_flag_if_condition_false_for("Ctffind", "use_noDW") is None
     # A non-negated flag on the SAME job must not be affected.
     assert draft_flag_is_negated("Class2D", "do_preread_images") is False
 

--- a/backend/tests/test_job_registry.py
+++ b/backend/tests/test_job_registry.py
@@ -166,6 +166,24 @@ def test_tomo_import_default_draft_suppresses_coordinate_branch_fields():
         assert suppressed not in d["unmapped_fields"], suppressed
 
 
+def test_tomo_import_dose_is_per_movie_frame_gets_dropdown_labels():
+    """job_catalog.BOOLEAN_SELECT_LABELS attaches boolean_labels onto a COPY
+    of this option (the frontend renders a two-way <select> instead of a
+    checkbox for it) without mutating the shared raw options list other
+    jobs/requests read from."""
+    d = job_registry.build_job_definition("TomoImport")
+    opts = {o["key"]: o for o in d["options"]}
+    assert opts["dose_is_per_movie_frame"]["boolean_labels"] == {
+        "false": "Dose per tilt image", "true": "Dose per movie frame",
+    }
+    # A field with no override still round-trips normally, and the raw data
+    # backing every OTHER job's build_job_definition call wasn't mutated.
+    assert "boolean_labels" not in opts["angpix"]
+    raw = job_registry.raw_job("TomoImport")
+    raw_opt = next(o for o in raw["options"] if o["key"] == "dose_is_per_movie_frame")
+    assert "boolean_labels" not in raw_opt
+
+
 def test_tomo_exclude_tilt_images_maps_its_hyphenated_flags():
     d = job_registry.build_job_definition("TomoExcludeTiltImages")
     draft = d["draft_command"]
@@ -816,6 +834,28 @@ def test_do_save_nodw_is_never_emitted_for_the_tomo_variant():
     fields = {"is_tomo": False, "do_dose_weighting": True, "do_save_noDW": True}
     cmd, _ = job_registry._build_draft_command(raw, fields, "TomoMotioncorr", "")
     assert "--save_noDW" not in cmd
+
+
+def test_tomoimport_dose_rate_switches_flag_with_dose_is_per_movie_frame():
+    """dose_rate previously always emitted --dose-per-tilt-image regardless
+    of dose_is_per_movie_frame -- confirmed as a real bug (checking "Is dose
+    rate per movie frame?" had no effect on the generated command) while
+    auditing issue #16. FlagOverride.flag_if_condition_false fixes it: the
+    SAME field's value now goes out under whichever of the two real flags
+    matches the checkbox, never both and never neither."""
+    raw = job_registry.raw_job("TomoImport")
+
+    cmd_tilt, unmapped_tilt = job_registry._build_draft_command(
+        raw, {"dose_is_per_movie_frame": False, "dose_rate": 3.5}, "TomoImport", "")
+    assert "--dose-per-tilt-image 3.5" in cmd_tilt
+    assert "--dose-per-movie-frame" not in cmd_tilt
+    assert "dose_rate" not in unmapped_tilt
+
+    cmd_movie, unmapped_movie = job_registry._build_draft_command(
+        raw, {"dose_is_per_movie_frame": True, "dose_rate": 1.2}, "TomoImport", "")
+    assert "--dose-per-movie-frame 1.2" in cmd_movie
+    assert "--dose-per-tilt-image" not in cmd_movie
+    assert "dose_rate" not in unmapped_movie
 
 
 @pytest.mark.parametrize("internal_name,on_fields,expect_substr,off_flip", _UNMAPPED_FIELD_FIXES)

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -326,6 +326,26 @@ function renderField(key, option, value) {
 
   switch (option.field_type) {
     case "boolean": {
+      // A handful of booleans (job_catalog.BOOLEAN_SELECT_LABELS, e.g.
+      // TomoImport's "Is dose rate per movie frame?") are easy to misread
+      // as a plain Yes/No checkbox when the two states aren't obviously
+      // opposite of each other -- those carry boolean_labels from the
+      // backend and get an explicit two-way dropdown instead. The value is
+      // still a plain bool either way; only the widget differs.
+      if (option.boolean_labels) {
+        const select = document.createElement("select");
+        [["false", option.boolean_labels.false], ["true", option.boolean_labels.true]].forEach(
+          ([v, label]) => {
+            const o = document.createElement("option");
+            o.value = v;
+            o.textContent = label;
+            if ((v === "true") === !!value) o.selected = true;
+            select.appendChild(o);
+          }
+        );
+        wrap.appendChild(select);
+        break;
+      }
       const input = document.createElement("input");
       input.type = "checkbox";
       input.checked = !!value;
@@ -411,7 +431,11 @@ function renderField(key, option, value) {
 
 function getFieldValue(fieldWrap, option) {
   const el = fieldWrap.querySelector("input, select, textarea");
-  if (option.field_type === "boolean") return el.checked;
+  if (option.field_type === "boolean") {
+    // boolean_labels fields render as <select>, not <input type=checkbox>
+    // (see renderField) -- el.checked is undefined on a <select>.
+    return option.boolean_labels ? el.value === "true" : el.checked;
+  }
   if (option.field_type === "slider") return parseFloat(el.value);
   return el.value;
 }


### PR DESCRIPTION
## Summary
- `dose_rate` needs one of two different flags (`--dose-per-tilt-image` / `--dose-per-movie-frame`) depending on the sibling "Is dose rate per movie frame?" checkbox. `FlagOverride` had no way to express that, and `dose_rate` was hardcoded to always emit `--dose-per-tilt-image` — a real bug, confirmed while auditing [#16](https://github.com/schiracha/RELION-US/issues/16): toggling the checkbox had zero effect on the generated draft command.
- Added `FlagOverride.flag_if_condition_false` so one option's own value can go out under an *alternate* flag when its condition evaluates false, instead of the existing present/absent-only behavior.
- Also render `dose_is_per_movie_frame` as an explicit two-way dropdown ("Dose per tilt image" / "Dose per movie frame") instead of an easy-to-miss Yes/No checkbox, via a new presentation-only overlay (`job_catalog.BOOLEAN_SELECT_LABELS`) — the underlying value is still a plain bool, `job_registry`/`DRAFT_OVERRIDES` need no changes to consume it, and every other field/job is unaffected.

Fixes #16.

## Test plan
- [x] `pytest backend/tests/` — 701 passed
- [x] New regression tests: `test_tomoimport_dose_rate_switches_flag_with_dose_is_per_movie_frame`, `test_flag_override_with_an_alternate_false_branch_flag`, `test_tomo_import_dose_is_per_movie_frame_gets_dropdown_labels`
- [x] Verified live in the browser: opened "Import Tomo Tilt Series", confirmed the field renders as a dropdown defaulting to "Dose per tilt image", switched it to "Dose per movie frame", recomputed the draft, and confirmed the command switched from `--dose-per-tilt-image 3` to `--dose-per-movie-frame 3` with no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)