### PR TITLE
Extend the picker's pick-diameter slider range and add a direct value input

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2763,8 +2763,8 @@ async function openVisualizer(pickingContext = null) {
           <label class="viz-check"><input type="checkbox" data-role="viz-crosshair" checked /> Show crosshair</label>
           <div class="viz-ctrl-row">
             <span class="viz-ctrl-key">Ø vox</span>
-            <input type="range" data-role="viz-diam" min="2" max="80" value="16" />
-            <span class="viz-ctrl-val" data-role="viz-diam-val">16</span>
+            <input type="range" data-role="viz-diam" min="2" max="400" value="16" />
+            <input type="number" class="viz-ctrl-val-input" data-role="viz-diam-val" min="2" max="2000" value="16" />
           </div>
           <div class="viz-ctrl-row">
             <span class="viz-ctrl-key">Line</span>
@@ -3157,10 +3157,26 @@ async function openVisualizer(pickingContext = null) {
   q('[data-role="viz-lo"]').addEventListener("input", contrastFromSliders);
   q('[data-role="viz-hi"]').addEventListener("input", contrastFromSliders);
 
-  q('[data-role="viz-diam"]').addEventListener("input", (e) => {
-    state.diameter = parseInt(e.target.value, 10);
-    q('[data-role="viz-diam-val"]').textContent = String(state.diameter);
+  const vizDiamSlider = q('[data-role="viz-diam"]');
+  const vizDiamInput = q('[data-role="viz-diam-val"]');
+  const diamMin = parseInt(vizDiamSlider.min, 10);
+  const diamSliderMax = parseInt(vizDiamSlider.max, 10);
+  // The slider's own max (400) is a practical drag range, not a hard cap --
+  // some box sizes run up to 600+, so the number input accepts anything up
+  // to DIAM_HARD_MAX and just pins the slider thumb at its end once a
+  // typed value passes 400, rather than rejecting it.
+  const DIAM_HARD_MAX = 2000;
+  function setDiameter(value) {
+    const clamped = Math.min(DIAM_HARD_MAX, Math.max(diamMin, value));
+    state.diameter = clamped;
+    vizDiamSlider.value = String(Math.min(clamped, diamSliderMax));
+    vizDiamInput.value = String(clamped);
     drawOverlays();
+  }
+  vizDiamSlider.addEventListener("input", (e) => setDiameter(parseInt(e.target.value, 10)));
+  vizDiamInput.addEventListener("input", (e) => {
+    const n = parseInt(e.target.value, 10);
+    if (!Number.isNaN(n)) setDiameter(n);
   });
   q('[data-role="viz-width"]').addEventListener("input", (e) => {
     state.width = parseInt(e.target.value, 10);

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -896,6 +896,12 @@ html, body {
 .viz-ctrl-row input[type="range"] { flex: 1; min-width: 0; }
 .viz-ctrl-key { color: var(--text-dim); width: 34px; flex-shrink: 0; }
 .viz-ctrl-val { color: var(--text-dim); width: 26px; text-align: right; flex-shrink: 0; }
+.viz-ctrl-val-input {
+  width: 42px; flex-shrink: 0; text-align: right;
+  background: var(--panel-alt); border: 1px solid var(--border);
+  color: var(--text); padding: 2px 4px; border-radius: 3px;
+  font-family: inherit; font-size: 11px;
+}
 .viz-check { display: flex; align-items: center; gap: 5px; font-size: 11px; }
 
 /* ---- Job Progress tab (live charts + class thumbnails) ---- */


### PR DESCRIPTION
## Summary
- The manual-picker viewer's "Ø vox" pick-circle-diameter control only went up to 80 voxels; box sizes of 400-600 are common for larger particles/structures.
- Raised the slider's own range to 400 and replaced the read-only value display with a number input, kept in sync with the slider in both directions.
- Typing a value above 400 (up to a 2000 hard cap) still works — the slider thumb just pins at its end rather than rejecting the value, since it's a practical drag range, not a hard limit.
- Purely a display setting (how large the pick circle is drawn on screen) — not saved into the particle STAR file, so no backend changes needed.

## Test plan
- [x] Verified live in the browser: loaded a test volume in the picker, confirmed the slider's new max (400) and the number input's max (2000) via DOM inspection
- [x] Typed 600 into the number input — slider correctly pinned at 400, number input kept 600
- [x] Dragged the slider — number input stayed in sync
- [x] Typed 120 into the number input via the real form — slider correctly moved to 120
- [x] No new console errors
- [x] `pytest backend/tests/` — 698 passed (frontend-only change, included as a sanity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)