### PR TITLE
Verify Motionrefine sigma_vel/sigma_div/sigma_acc already work correctly (no fix needed)

### DIFF
--- a/backend/tests/test_job_registry.py
+++ b/backend/tests/test_job_registry.py
@@ -836,6 +836,36 @@ def test_do_save_nodw_is_never_emitted_for_the_tomo_variant():
     assert "--save_noDW" not in cmd
 
 
+def test_motionrefine_sigma_fields_already_work_via_generic_extractor():
+    """GitHub issue #22 assumed sigma_vel/sigma_div/sigma_acc needed a new
+    DRAFT_OVERRIDES entry. Verified false: all three already have a
+    correctly-extracted option_flags entry (flag + a two-clause `&&`
+    condition, both joboptions["x"].getBoolean()-shaped) that
+    _evaluate_condition already handles with no override at all. At
+    Motionrefine's real defaults (do_polish=True, do_own_params=False)
+    the condition correctly evaluates False -- because it's
+    do_own_params, not do_polish, that's off by default -- and the
+    fields are silently omitted, not unmapped, which is why nobody
+    noticed they already worked. This pins that behavior directly
+    instead of adding an unnecessary DRAFT_OVERRIDES entry."""
+    raw = job_registry.raw_job("Motionrefine")
+    fields_on = {
+        "do_polish": True, "do_own_params": True,
+        "sigma_vel": 1.5, "sigma_div": 2500, "sigma_acc": 3,
+    }
+    cmd_on, unmapped_on = job_registry._build_draft_command(raw, fields_on, "Motionrefine", "")
+    assert "--s_vel 1.5" in cmd_on
+    assert "--s_div 2500" in cmd_on
+    assert "--s_acc 3" in cmd_on
+    assert not any(k in unmapped_on for k in ("sigma_vel", "sigma_div", "sigma_acc"))
+
+    fields_off = {**fields_on, "do_own_params": False}
+    cmd_off, unmapped_off = job_registry._build_draft_command(raw, fields_off, "Motionrefine", "")
+    for flag in ("--s_vel", "--s_div", "--s_acc"):
+        assert flag not in cmd_off, cmd_off
+    assert not any(k in unmapped_off for k in ("sigma_vel", "sigma_div", "sigma_acc"))
+
+
 def test_tomoimport_dose_rate_switches_flag_with_dose_is_per_movie_frame():
     """dose_rate previously always emitted --dose-per-tilt-image regardless
     of dose_is_per_movie_frame -- confirmed as a real bug (checking "Is dose


### PR DESCRIPTION
## Summary

GitHub issue #22 claimed `backend/job_catalog.py`'s `DRAFT_OVERRIDES["Motionrefine"]` entry needed new `FlagOverride` entries for `sigma_vel`/`sigma_div`/`sigma_acc` to match the RELION source (`pipeline_jobs.cpp`, `getCommandsMotionrefineJob`, ~line 5932-5940).

That premise was verified false during planning and re-verified here: all three fields already have a correctly-extracted `option_flags` entry (flag + a two-clause `&&` condition, both `joboptions["x"].getBoolean()`-shaped) that the existing `job_registry._evaluate_condition` already handles correctly, with zero code changes needed. At Motionrefine's real defaults (`do_polish=True`, `do_own_params=False`), the condition correctly evaluates `False` because `do_own_params` gates it, and the fields are silently (and correctly) omitted from the draft command -- not marked `unmapped` -- which is why nobody previously noticed they already worked.

- No production code changed (`backend/job_catalog.py` and `backend/job_registry.py` are untouched).
- Added one regression test, `test_motionrefine_sigma_fields_already_work_via_generic_extractor`, in `backend/tests/test_job_registry.py`, pinning this behavior directly (both the "on" case emitting `--s_vel`/`--s_div`/`--s_acc`, and the "off" case correctly omitting them with nothing unmapped).

This PR does **not** close #22 automatically -- that needs explicit confirmation from the coordinator/user, so no `Fixes #22` / `Closes #22` keyword is used here.

## Test plan

- [x] Manually verified `option_flags` extraction and `_build_draft_command` output for Motionrefine directly against `job_registry` (see commit description / PR summary above)
- [x] `cd backend && ../relion-us/bin/python3 -m pytest tests/ -q` -- 702 passed (701 baseline + 1 new test), zero regressions
- [x] Ran `code-review` skill against the diff -- one docstring inaccuracy found and fixed before commit (default value claim), no other issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)