### PR TITLE
Fix draft-command gaps missed by || conditions (Autopick do_write_fom_maps/do_read_fom_maps)

### DIFF
--- a/backend/job_catalog.py
+++ b/backend/job_catalog.py
@@ -1055,6 +1055,16 @@ DRAFT_OVERRIDES: dict[str, JobDraftOverride] = {
             # do_helix-gated range_rot/range_tilt/range_psi.
             "do_pick_helical_segments": FlagOverride("--helix", condition="do_refs"),
             "do_amyloid": FlagOverride("--amyloid", condition="do_refs && do_pick_helical_segments"),
+            # `if (joboptions["do_refs"].getBoolean() || joboptions["do_log"]
+            # .getBoolean()) { if (do_write_fom_maps) command += "
+            # --write_fom_maps "; if (do_read_fom_maps) command += "
+            # --read_fom_maps "; }` (~2398-2410) -- both self-guarded
+            # booleans, but nested under a top-level `||` between Autopick's
+            # two picking-with-a-reference modes (LoG vs. references), which
+            # job_registry._evaluate_condition can now evaluate (see its
+            # OR-support, added for exactly this case -- issue #15).
+            "do_write_fom_maps": FlagOverride("--write_fom_maps", condition="do_refs || do_log"),
+            "do_read_fom_maps": FlagOverride("--read_fom_maps", condition="do_refs || do_log"),
         },
         suppress=frozenset({"use_gpu"}),
     ),
@@ -1168,8 +1178,6 @@ DRAFT_OVERRIDES: dict[str, JobDraftOverride] = {
 # entry at all, across every job type, cross-checked against real source --
 # see test_job_registry.py's _UNMAPPED_FIELD_FIXES for the ones that WERE
 # safe to fix). Left unmapped rather than guessed:
-#   - Autopick.do_write_fom_maps/do_read_fom_maps: condition is `do_refs ||
-#     do_log` (~2398) -- _evaluate_condition only supports `&&`, not `||`.
 #   - Autopick.do_topaz_filaments/topaz-internal fields, Motionrefine.
 #     do_own_params, Select.do_recenter (needs a `fnt.contains("Class2D/")`
 #     string check, ~2988), TomoDenoiseTomograms.do_cryocare_train/predict,

--- a/backend/job_registry.py
+++ b/backend/job_registry.py
@@ -220,7 +220,15 @@ def _split_top_level_and(condition: str) -> list[str] | None:
     (defer to the caller's existing "unmapped" fallback) the moment the
     condition contains an `||` or the literal token `else` anywhere -- both
     mean real branch logic this app deliberately doesn't try to interpret
-    (see the module docstring)."""
+    (see the module docstring).
+
+    Known, deliberate remaining limitation: a `||` nested inside parens,
+    e.g. `(a || b) && c`, is invisible to this function's own naive
+    `"||" in condition` check just as much as it is to
+    _split_top_level_or's depth-tracking splitter (added alongside this
+    note) -- neither looks inside parens for it. This is fine: the failure
+    mode is always "returns None -> unmapped", never a wrong guess, and no
+    current job in job_catalog.DRAFT_OVERRIDES needs it fixed."""
     if "||" in condition or re.search(r"\belse\b", condition):
         return None
     clauses: list[str] = []
@@ -246,35 +254,74 @@ def _split_top_level_and(condition: str) -> list[str] | None:
     return [c.strip() for c in clauses if c.strip()]
 
 
-def _evaluate_condition(
+def _split_top_level_or(condition: str) -> list[str] | None:
+    """Split `condition` on `||` that sits outside any parentheses -- same
+    depth-tracking shape as _split_top_level_and, but for the operator
+    that binds LOOSEST in C, so splitting on it first (before any `&&`
+    splitting happens per branch) is the correct grammar decomposition:
+    each resulting branch is itself an AND-clause (or a single term),
+    evaluated independently by _evaluate_and_clauses. None (defer to the
+    caller's "unmapped" fallback) the moment the condition contains the
+    literal token `else` anywhere -- same reasoning as
+    _split_top_level_and. A condition with no top-level `||` at all (the
+    common case) still returns a single-element list holding the whole
+    condition unchanged.
+    """
+    if re.search(r"\belse\b", condition):
+        return None
+    clauses: list[str] = []
+    current: list[str] = []
+    depth = 0
+    i = 0
+    while i < len(condition):
+        ch = condition[i]
+        if ch == "(":
+            depth += 1
+            current.append(ch)
+        elif ch == ")":
+            depth -= 1
+            current.append(ch)
+        elif depth == 0 and condition[i : i + 2] == "||":
+            clauses.append("".join(current))
+            current = []
+            i += 1  # skip the second '|'
+        else:
+            current.append(ch)
+        i += 1
+    clauses.append("".join(current))
+    return [c.strip() for c in clauses if c.strip()]
+
+
+def _evaluate_and_clauses(
     condition: str, field_values: dict[str, Any], known_keys: set[str] | None = None
 ) -> bool | None:
-    """Best-effort evaluation of a RELION `if (...)` condition against the
-    CURRENT field values -- not a guess, but replaying the exact same
+    """Best-effort evaluation of ONE `&&`-joined OR-branch (or a whole
+    condition with no top-level `||` at all) against the CURRENT field
+    values -- not a guess, but replaying the exact same
     `joboptions["X"].getBoolean()` check RELION's own getCommands*Job()
-    would make, using the identical field data the user submitted (e.g.
-    "only pass --helical_nr_asu when the Helical processing checkbox is
-    actually on").
+    would make. This is _evaluate_condition's original single-branch body,
+    kept intact and given its own name so _evaluate_condition can dispatch
+    across OR-branches (see its own docstring) before delegating each one
+    here.
 
     known_keys: this job's real option keys (from `options_by_key`), used
     only to decide whether a bare identifier clause (see _BARE_IDENT_RE) is
     safe to resolve -- an identifier that isn't one of this job's own
     options is left unresolved rather than guessed at.
 
-    Returns True/False when every top-level `&&`-joined clause is one of the
-    recognized, safely-evaluable shapes: a boolean field's own value
-    (optionally negated, as either `joboptions["x"].getBoolean()` or the
-    bare local-variable form some jobs use instead -- see _BARE_IDENT_RE),
-    the `is_continue` invariant (a fixed constant in this app -- see below),
-    or `is_tomo`/`!is_tomo` (read from field_values["is_tomo"] when present,
-    see below). Returns None the moment anything else shows up -- an `||`,
-    an `else` branch marker, a numeric/string comparison, a call this
+    Returns True/False when every top-level `&&`-joined clause in THIS
+    branch is one of the recognized, safely-evaluable shapes: a boolean
+    field's own value (optionally negated, as either
+    `joboptions["x"].getBoolean()` or the bare local-variable form some
+    jobs use instead -- see _BARE_IDENT_RE), the `is_continue` invariant
+    (a fixed constant in this app -- see below), or `is_tomo`/`!is_tomo`
+    (read from field_values["is_tomo"] when present, see below). Returns
+    None the moment anything else shows up within this branch -- an
+    `else` branch marker, a numeric/string comparison, a call this
     function doesn't recognize -- so the caller falls back to marking the
-    field "unmapped" exactly as it did before this evaluator existed, rather
-    than risk a wrong guess.
+    field "unmapped" exactly as it did before this evaluator existed,
+    rather than risk a wrong guess.
     """
-    if not condition:
-        return True
     clauses = _split_top_level_and(condition)
     if clauses is None:
         return None
@@ -338,6 +385,47 @@ def _evaluate_condition(
             # being false settles the whole clause).
             return False
     return result
+
+
+def _evaluate_condition(
+    condition: str, field_values: dict[str, Any], known_keys: set[str] | None = None
+) -> bool | None:
+    """Best-effort evaluation of a RELION `if (...)` condition against the
+    CURRENT field values. Splits the WHOLE condition into top-level `||`
+    branches first (correct C precedence: `||` binds loosest), then
+    evaluates each branch as its own `&&`-joined clause list via
+    _evaluate_and_clauses (see its docstring for the recognized clause
+    shapes). Short-circuits like real `||`: True the moment any branch is
+    True (doesn't need every branch to be evaluable); if no branch is True
+    but at least one couldn't be evaluated, the overall verdict is None
+    (can't be sure); False only once every branch cleanly evaluates to
+    False. A condition with no top-level `||` at all degenerates to
+    exactly one branch, so this also covers what used to be
+    _evaluate_condition's entire body for every plain-AND condition
+    already in this app.
+
+    known_keys: passed through unchanged to _evaluate_and_clauses.
+
+    Returns None the moment anything unrecognized shows up anywhere -- an
+    `else` branch marker, a numeric/string comparison, a call this
+    function doesn't recognize, or an `||` whose branches straddle a
+    paren boundary this app's splitting doesn't look inside (see
+    _split_top_level_and's docstring) -- so the caller falls back to
+    marking the field "unmapped" rather than risk a wrong guess.
+    """
+    if not condition:
+        return True
+    or_clauses = _split_top_level_or(condition)
+    if or_clauses is None:
+        return None
+    saw_none = False
+    for clause in or_clauses:
+        verdict = _evaluate_and_clauses(clause, field_values, known_keys)
+        if verdict is True:
+            return True
+        if verdict is None:
+            saw_none = True
+    return None if saw_none else False
 
 
 def _build_draft_command(
@@ -495,6 +583,29 @@ def _build_draft_command(
                 condition = pair.get("condition", "")
                 if _self_guarded(condition, key):
                     flag = pair["flag"]
+                elif "||" in condition:
+                    # The extractor builds this condition string by
+                    # concatenating RELION's own nested `if` blocks with
+                    # `&&`, which silently drops the parens around an OUTER
+                    # condition that itself contains a top-level `||`
+                    # (confirmed for real: MultiBody's gpu_ids/nr_pool/
+                    # nr_threads/scratch_dir and DynaMight's fn_star and
+                    # friends are actually `if (OUTER_WITH_OR) { ... if
+                    # (INNER) ... } }`, extracted as the flattened, wrongly-
+                    # associating text "OUTER_WITH_OR && INNER" -- see
+                    # pipeline_jobs.cpp's getCommandsMultiBodyJob ~111-196).
+                    # _evaluate_condition's OR support (issue #15) assumes
+                    # its input is a faithful transcription of one real `if`
+                    # condition -- true for job_catalog.DRAFT_OVERRIDES'
+                    # hand-verified mapped_condition (checked above, at the
+                    # "not None" branch of `mapped`), NOT reliably true for
+                    # this extracted, auto-flattened text. Stay deferred to
+                    # "unmapped" for any extracted condition containing
+                    # `||`, exactly as before OR support existed, rather
+                    # than risk replaying a condition whose grouping isn't
+                    # actually what RELION's source means.
+                    unmapped.append(key)
+                    continue
                 else:
                     # Not self-guarded doesn't have to mean "give up": this
                     # app has the SAME field_values RELION's own

--- a/backend/tests/test_job_registry.py
+++ b/backend/tests/test_job_registry.py
@@ -754,6 +754,10 @@ _UNMAPPED_FIELD_FIXES = [
     ("Autopick",
      {"do_refs": True, "do_pick_helical_segments": True, "do_amyloid": True},
      "--amyloid", ("do_pick_helical_segments", False)),
+    ("Autopick", {"do_refs": True, "do_write_fom_maps": True}, "--write_fom_maps", ("do_refs", False)),
+    ("Autopick", {"do_log": True, "do_write_fom_maps": True}, "--write_fom_maps", ("do_log", False)),
+    ("Autopick", {"do_refs": True, "do_read_fom_maps": True}, "--read_fom_maps", ("do_refs", False)),
+    ("Autopick", {"do_log": True, "do_read_fom_maps": True}, "--read_fom_maps", ("do_log", False)),
     ("Autorefine", {"ref_correct_greyscale": False}, "--firstiter_cc", ("ref_correct_greyscale", True)),
     ("Autorefine", {"do_zero_mask": True}, "--zero_mask", None),
     ("Autorefine", {"fn_mask": "m.mrc", "do_solvent_fsc": True}, "--solvent_correct_fsc", ("fn_mask", "")),
@@ -920,7 +924,17 @@ def test_jobs_without_a_suffix_entry_keep_the_bare_directory():
         True,
     ),
     # Unevaluable shapes defer to the caller's existing "unmapped" fallback.
-    ('joboptions["a"].getBoolean() || joboptions["b"].getBoolean()', {"a": True}, None),
+    # || support (issue #15): True the moment either branch is True --
+    # matches real short-circuit OR, doesn't need the other branch
+    # evaluable. Expected value flips from None (pre-#15, when
+    # _evaluate_condition had no OR support at all) to True now that
+    # _split_top_level_or handles top-level `||`.
+    ('joboptions["a"].getBoolean() || joboptions["b"].getBoolean()', {"a": True}, True),
+    ('joboptions["a"].getBoolean() || joboptions["b"].getBoolean()', {"a": False, "b": False}, False),
+    # One branch cleanly False, the other unevaluable -- still None, since
+    # we can't be sure the true branch wouldn't have made it True.
+    ('joboptions["a"].getBoolean() || joboptions["nr_split"].getNumber(error_message) > 0',
+     {"a": False}, None),
     ('else && joboptions["do_topaz"].getBoolean()', {"do_topaz": True}, None),
     ('joboptions["nr_split"].getNumber(error_message) > 0', {"nr_split": 5}, None),
 ])
@@ -951,9 +965,38 @@ def test_evaluate_condition(condition, field_values, expected):
     # opposite polarity, and doesn't need to be in known_keys since it's a
     # RelionJob state flag, not a real JobOption.
     ("is_continue", {}, set(), False),
+    # Bare-identifier OR (issue #15's concrete Autopick shape: `do_refs ||
+    # do_log`, pipeline_jobs.cpp ~2398).
+    ("do_refs || do_log", {"do_refs": False, "do_log": True}, {"do_refs", "do_log"}, True),
+    ("do_refs || do_log", {"do_refs": False, "do_log": False}, {"do_refs", "do_log"}, False),
 ])
 def test_evaluate_condition_bare_identifier(condition, field_values, known_keys, expected):
     assert job_registry._evaluate_condition(condition, field_values, known_keys) is expected
+
+
+def test_extracted_or_condition_stays_unmapped_not_wrongly_evaluated():
+    """_evaluate_condition's new || support (issue #15) is safe for
+    job_catalog.DRAFT_OVERRIDES' hand-verified mapped_condition strings (the
+    Autopick do_write_fom_maps/do_read_fom_maps fix), but NOT safe to turn
+    loose on the auto-extracted option_flags condition text: the extractor
+    flattens RELION's nested `if` blocks into one `&&`-joined string,
+    silently dropping the parens around an outer condition that itself
+    contains a top-level `||`. Confirmed for real against
+    getCommandsMultiBodyJob (pipeline_jobs.cpp ~111-196): the true structure
+    is `if (!is_continue || (is_continue && fn_cont != "")) { ... if
+    (use_gpu) { --gpu } }`, extracted as the flattened text
+    `!is_continue || (is_continue && fn_cont != "") && use_gpu` -- naively
+    OR-splitting THAT string (top-level `||` binds loosest) makes
+    `!is_continue` alone satisfy the whole condition, since is_continue is
+    always false in this app, so --gpu would be emitted unconditionally
+    regardless of the "Use GPU acceleration?" checkbox. gpu_ids must stay
+    unmapped instead, exactly as it did before OR support existed."""
+    raw = job_registry.raw_job("MultiBody")
+    cmd, unmapped = job_registry._build_draft_command(
+        raw, {"use_gpu": False, "gpu_ids": ""}, "MultiBody", ""
+    )
+    assert "--gpu" not in cmd, cmd
+    assert "gpu_ids" in unmapped
 
 
 def test_helical_fields_are_omitted_when_the_checkbox_is_unchecked():


### PR DESCRIPTION
## Summary
- `_evaluate_condition` (backend/job_registry.py) only understood `&&`-joined clauses; any condition containing a top-level `||` returned `None` and the field was permanently marked `unmapped_fields`. Autopick's `do_write_fom_maps`/`do_read_fom_maps` are gated by `do_refs || do_log` (pipeline_jobs.cpp `getCommandsAutopickJob`, ~2398), so they were always unmapped.
- Adds `_split_top_level_or` (same depth-tracking shape as the existing `_split_top_level_and`) and splits the old single-branch `_evaluate_condition` body into a new `_evaluate_and_clauses` helper. `_evaluate_condition` is now a thin dispatcher: it splits on top-level `||` first (correct C precedence — `||` binds loosest), then evaluates each branch with `_evaluate_and_clauses`, short-circuiting True the moment any branch is True, matching real OR semantics.
- Wires up `job_catalog.DRAFT_OVERRIDES["Autopick"]` with `do_write_fom_maps`/`do_read_fom_maps`, both `condition="do_refs || do_log"`, and removes the now-stale "Deliberately NOT included" bullet documenting the old gap.
- **Safety fix found during code review**: the generic OR-evaluator is also reachable from the auto-extracted `option_flags` condition text (not just the hand-verified `DRAFT_OVERRIDES` entries). That extractor flattens RELION's nested `if` blocks into one `&&`-joined string, silently dropping the parens around an outer condition that itself has a top-level `||`. Confirmed for real against `getCommandsMultiBodyJob` (pipeline_jobs.cpp ~111-196): the true structure is `if (!is_continue || (is_continue && fn_cont != "")) { ... if (use_gpu) { --gpu } }`, extracted as the flattened text `!is_continue || (is_continue && fn_cont != "") && use_gpu`. Naively OR-splitting that string makes `!is_continue` alone (always true in this app) satisfy the whole condition, so `--gpu ''` would be emitted unconditionally regardless of the "Use GPU acceleration?" checkbox — a real regression, also reproduced for several `Select`/`DynaMight` fields. Fixed by keeping the extracted-`option_flags` fallback path deferred to "unmapped" for any condition containing `||`, exactly as it behaved before this PR; only hand-verified `DRAFT_OVERRIDES` conditions (like Autopick's) get OR support.

## Test plan
- [x] `python3 -m ast` syntax check on `job_registry.py`, `job_catalog.py`, `tests/test_job_registry.py`
- [x] Full backend suite: `pytest tests/ -q` — 710 passed (up from a 701 baseline, +9 new tests), zero regressions
- [x] Manual verification: Autopick draft command now includes `--write_fom_maps`/`--read_fom_maps` under both OR-branches (`do_refs` and `do_log`), and no longer lists them in `unmapped_fields`
- [x] Manual verification: MultiBody's `gpu_ids` (and Select's mutually-exclusive discard/split fields) still correctly stay unmapped rather than emitting wrong flags

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)