### PR TITLE
Update the RELION-sync-open project warning message wording

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2340,8 +2340,7 @@ function maybeWarnAboutOpenRelionGuis() {
     "Close any native RELION GUI you have open on this project folder before " +
     "continuing — a GUI that's already open keeps its own copy of the pipeline " +
     "and won't see these updates, which risks corrupting the project if both " +
-    "write to it. Once closed, use RELION-US as the only interface to this " +
-    "project."
+    "write to it. Use one UI at a time or risk corrupting the project files."
   );
 }
 


### PR DESCRIPTION
## Summary
- Simplify the trailing sentence of the pipeline-sync safety warning shown by `maybeWarnAboutOpenRelionGuis` in `frontend/app.js` from "Once closed, use RELION-US as the only interface to this project." to "Use one UI at a time or risk corrupting the project files."
- No other dialog was touched — the separate "turn on sync" `confirmDialog` nearby keeps its existing wording unchanged.

Fixes #31

## Test plan
- [x] `node --check frontend/app.js` passes
- [x] Grepped to confirm the old sentence is gone from `maybeWarnAboutOpenRelionGuis` and the unrelated "turn on sync" dialog text ("as the only interface to it afterward") is unchanged
- [x] `git diff` confirms only the intended sentence changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)