### PR TITLE
Fix TomoAlign/TomoCtfRefine's in_halfmaps -> --ref1/--ref2

### DIFF
--- a/backend/job_catalog.py
+++ b/backend/job_catalog.py
@@ -24,6 +24,7 @@ subprocess (see job_runner.py).
 """
 
 import functools
+import shlex
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
@@ -713,6 +714,49 @@ def _extract_extra_flags(field_values: dict) -> list:
     return _extract_bg_radius_flags(field_values) + _extract_helical_nr_asu_rise_fallback_flags(field_values)
 
 
+def _tomo_other_half(filename: str) -> Optional[str]:
+    """Python port of FileName::getTheOtherHalf (src/filename.cpp:456-472,
+    confirmed current): operates on the BASENAME only (a directory
+    component containing "half1"/"half2" in its own name is left
+    untouched), replaces ALL occurrences (str.replace with no count arg
+    already does this, same as C++'s replaceAllSubstrings), case-sensitive.
+    None if neither "half1" nor "half2" appears anywhere in the basename --
+    real RELION hard-errors and refuses to build the command in that case;
+    this app's policy is to omit the flags entirely instead (see
+    _tomo_ref1_ref2_flags below), not guess."""
+    directory, sep, basename = filename.rpartition("/")
+    if "half1" in basename:
+        new_basename = basename.replace("half1", "half2")
+    elif "half2" in basename:
+        new_basename = basename.replace("half2", "half1")
+    else:
+        return None
+    return f"{directory}{sep}{new_basename}" if sep else new_basename
+
+
+def _tomo_ref1_ref2_flags(field_values: dict) -> list:
+    """TomoAlign/TomoCtfRefine's in_halfmaps -> --ref1/--ref2
+    (getCommandsTomoAlignJob ~7328-7347, getCommandsTomoCtfRefineJob
+    ~7189-7208, byte-identical logic, confirmed current): fn_half2 is
+    derived from fn_half1 by FileName::getTheOtherHalf (a half1<->half2
+    string swap on the basename only -- see _tomo_other_half above), not
+    read from any field of its own. Emits nothing at all (never a
+    half-complete --ref1 alone) when in_halfmaps is empty or the swap
+    fails -- matching real RELION's own hard error in that case; this
+    app's policy is to silently omit rather than guess. Shared verbatim by
+    both jobs since the C++ logic is identical in both getCommands*Job()s.
+    Values are shell-quoted (unlike Extract's earlier extra_flags
+    builders, which only ever emitted computed numbers) since in_halfmaps
+    is a real filesystem path that can contain spaces."""
+    fn_half1 = str(field_values.get("in_halfmaps") or "").strip()
+    if not fn_half1:
+        return []
+    fn_half2 = _tomo_other_half(fn_half1)
+    if fn_half2 is None:
+        return []
+    return ["--ref1", shlex.quote(fn_half1), "--ref2", shlex.quote(fn_half2)]
+
+
 DRAFT_OVERRIDES: dict[str, JobDraftOverride] = {
     # getCommandsTomoImportJob, DEFAULT branch (do_coords == false):
     #   command = "relion_python_tomo_import SerialEM ..."
@@ -1010,7 +1054,8 @@ DRAFT_OVERRIDES: dict[str, JobDraftOverride] = {
             "do_frame_scale": FlagOverride("--per_frame_scale"),  # ~7255
             "do_tomo_scale": FlagOverride("--per_tomo_scale"),  # ~7256
         },
-        suppress=frozenset({"use_direct_entries"}),
+        suppress=frozenset({"use_direct_entries", "in_halfmaps"}),
+        extra_flags=_tomo_ref1_ref2_flags,
     ),
     "TomoAlign": JobDraftOverride(
         flags={
@@ -1025,7 +1070,8 @@ DRAFT_OVERRIDES: dict[str, JobDraftOverride] = {
             "do_motion": FlagOverride("--motion"),  # ~7384/7403, same local-copy shape
             "do_sq_exp_ker": FlagOverride("--sq_exp_ker", condition="do_motion"),  # ~7408
         },
-        suppress=frozenset({"use_direct_entries"}),
+        suppress=frozenset({"use_direct_entries", "in_halfmaps"}),
+        extra_flags=_tomo_ref1_ref2_flags,
     ),
     "TomoReconPart": JobDraftOverride(
         flags={
@@ -1446,11 +1492,6 @@ DRAFT_OVERRIDES: dict[str, JobDraftOverride] = {
 #     computed (diameter->radius, extract_size- and do_rescale-dependent,
 #     ~2584-2600); the helix branch hardcodes "--helical_nr_asu 1
 #     --helical_rise 1" in its else (~2629), not read from any field.
-#   - TomoAlign/TomoCtfRefine.in_halfmaps: only half of the pair
-#     (`--ref1 <in_halfmaps>`) is a plain passthrough -- `--ref2` is derived
-#     by string substitution (getTheOtherHalf, "half1"->"half2" in the
-#     filename), not any option's own value. Mapping just --ref1 would make
-#     an incomplete command look complete; left fully unmapped instead.
 #   - TomoImport.dose_is_per_movie_frame: the SAME "dose_rate" field needs a
 #     DIFFERENT flag (--dose-per-movie-frame vs --dose-per-tilt-image)
 #     depending on this boolean (~6506) -- one option key, two possible

--- a/backend/tests/test_job_catalog.py
+++ b/backend/tests/test_job_catalog.py
@@ -229,6 +229,23 @@ def test_extra_flags_extract_helical_fallback_absent_once_cutting_into_segments(
     ) == []
 
 
+def test_extra_flags_tomo_other_half_swap_both_directions():
+    assert job_catalog._tomo_other_half("job001/half1_class001.mrc") == "job001/half2_class001.mrc"
+    assert job_catalog._tomo_other_half("job001/half2_class001.mrc") == "job001/half1_class001.mrc"
+    assert job_catalog._tomo_other_half("job001/reference.mrc") is None
+    assert job_catalog._tomo_other_half("half1_only.mrc") == "half2_only.mrc"  # no directory component
+
+
+def test_extra_flags_tomoalign_ref1_ref2():
+    assert draft_extra_flags("TomoAlign", {"in_halfmaps": "d/half1_x.mrc"}) == \
+        ["--ref1", "d/half1_x.mrc", "--ref2", "d/half2_x.mrc"]
+
+
+def test_extra_flags_tomoalign_ref1_ref2_empty_input_returns_nothing():
+    assert draft_extra_flags("TomoAlign", {"in_halfmaps": ""}) == []
+    assert draft_extra_flags("TomoCtfRefine", {}) == []
+
+
 def test_extra_flags_default_job_returns_nothing():
     assert draft_extra_flags("Motioncorr", {}) == []
 

--- a/backend/tests/test_job_registry.py
+++ b/backend/tests/test_job_registry.py
@@ -693,6 +693,26 @@ def test_tomoalign_motion_sigma_fields_are_emitted_when_do_motion_is_on():
     assert not ({"sigma_vel", "sigma_div"} & set(unmapped))
 
 
+def test_tomoalign_in_halfmaps_omits_both_flags_when_swap_fails():
+    """No "half1"/"half2" substring anywhere in the basename -- real RELION
+    hard-errors; this app omits both flags rather than emit an incomplete
+    or guessed pair."""
+    raw = job_registry.raw_job("TomoAlign")
+    cmd, unmapped = job_registry._build_draft_command(
+        raw, {"in_halfmaps": "job001/reference_map.mrc"}, "TomoAlign", "")
+    assert "--ref1" not in cmd
+    assert "--ref2" not in cmd
+    assert "in_halfmaps" not in unmapped
+
+
+def test_tomoctfrefine_in_halfmaps_quotes_paths_with_spaces():
+    raw = job_registry.raw_job("TomoCtfRefine")
+    cmd, _ = job_registry._build_draft_command(
+        raw, {"in_halfmaps": "My Project/half1 map.mrc"}, "TomoCtfRefine", "")
+    assert "--ref1 'My Project/half1 map.mrc'" in cmd
+    assert "--ref2 'My Project/half2 map.mrc'" in cmd
+
+
 @pytest.mark.parametrize("internal_name", ["Class2D", "Class3D", "Autorefine", "Inimodel"])
 def test_do_ctf_correction_emits_ctf_flag(internal_name):
     """pipeline_jobs.cpp wraps this in a nested `if (!is_continue) { if
@@ -844,6 +864,10 @@ _UNMAPPED_FIELD_FIXES = [
     ("TomoAlign", {"do_shift_align": True}, "--shift_only", None),
     ("TomoAlign", {"do_motion": True}, "--motion", None),
     ("TomoAlign", {"do_motion": True, "do_sq_exp_ker": True}, "--sq_exp_ker", ("do_motion", False)),
+    ("TomoAlign", {"in_halfmaps": "job001/half1_class001.mrc"},
+     "--ref1 job001/half1_class001.mrc --ref2 job001/half2_class001.mrc", ("in_halfmaps", "")),
+    ("TomoCtfRefine", {"in_halfmaps": "job001/half2_class001.mrc"},
+     "--ref1 job001/half2_class001.mrc --ref2 job001/half1_class001.mrc", ("in_halfmaps", "")),
     ("TomoAlignTiltSeries", {"do_imod_fiducials": True}, "--imod_fiducials", None),
     ("TomoAlignTiltSeries", {"do_imod_patchtrack": True}, "--imod_patchtrack", None),
     ("TomoAlignTiltSeries", {"do_aretomo2": True}, "--aretomo2", None),


### PR DESCRIPTION
## Summary

- `TomoAlign` and `TomoCtfRefine` both take a single half-map filename (`in_halfmaps`) but need to emit `--ref1 <half1> --ref2 <half2>` together, deriving the other half's filename by string substitution — that field was previously left completely unmapped, so no `--ref1`/`--ref2` flags were ever generated in the draft command.
- Adds `_tomo_other_half()`, a Python port of `FileName::getTheOtherHalf` (`src/filename.cpp:456-472`): basename-only, case-sensitive, replaces all `half1`/`half2` occurrences, returns `None` when neither substring is found (matching real RELION's own hard error in that case).
- Adds `_tomo_ref1_ref2_flags()`, the shared `extra_flags` hook used by both jobs' `DRAFT_OVERRIDES` entries (`getCommandsTomoAlignJob` ~7328-7347 and `getCommandsTomoCtfRefineJob` ~7189-7208 have byte-identical `--ref1`/`--ref2` construction), shell-quoting both paths since `in_halfmaps` is a real filesystem path that can contain spaces.
- `in_halfmaps` is added to both jobs' `suppress` set so it no longer shows up as unmapped, and the now-stale "Deliberately NOT included" comment explaining the old unmapped state is removed.

Fixes #19

## Test plan

- [x] Added `_tomo_other_half`/`_tomo_ref1_ref2_flags` unit tests in `backend/tests/test_job_catalog.py`
- [x] Added `TomoAlign`/`TomoCtfRefine` rows to `_UNMAPPED_FIELD_FIXES` plus two dedicated tests (swap-fails omission, space-containing-path quoting) in `backend/tests/test_job_registry.py`
- [x] Full backend suite: `748 passed` (baseline was 741; +7 new tests, zero regressions)
- [x] Verified against real RELION source (`/home/schiracha/relion/src/filename.cpp:456-472`, `/home/schiracha/relion/src/pipeline_jobs.cpp:7189-7208`/`:7328-7347`)
- [x] Ran the `code-review` skill — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
