### PR TITLE
Add a field.contains(literal) condition clause; fix Select.do_recenter

### DIFF
--- a/backend/job_catalog.py
+++ b/backend/job_catalog.py
@@ -1356,6 +1356,14 @@ DRAFT_OVERRIDES: dict[str, JobDraftOverride] = {
             # `else if (do_split) { command += " --split "; if (do_random)
             # command += " --random_order "; ... }` (~2861-2870).
             "do_random": FlagOverride("--random_order", condition="do_split"),
+            # `FileName fnt = joboptions["fn_model"].getString(); if
+            # (fnt.contains("Class2D/")) { ... if (do_recenter) command +=
+            # " --recenter "; }` (~2977-2990) -- do_recenter's OWN boolean
+            # check happens automatically afterward via the normal
+            # boolean-field emit logic (same as every other FlagOverride);
+            # this condition only needs to encode the ADDITIONAL fn_model
+            # substring check (issue #23).
+            "do_recenter": FlagOverride("--recenter", condition='fn_model.contains("Class2D/")'),
         },
     ),
     "Subtract": JobDraftOverride(
@@ -1425,8 +1433,7 @@ DRAFT_OVERRIDES: dict[str, JobDraftOverride] = {
 # see test_job_registry.py's _UNMAPPED_FIELD_FIXES for the ones that WERE
 # safe to fix). Left unmapped rather than guessed:
 #   - Autopick.do_topaz_filaments/topaz-internal fields, Motionrefine.
-#     do_own_params, Select.do_recenter (needs a `fnt.contains("Class2D/")`
-#     string check, ~2988), TomoDenoiseTomograms.do_cryocare_train/predict,
+#     do_own_params, TomoDenoiseTomograms.do_cryocare_train/predict,
 #     Subtract.do_fliplabel: each switches to a genuinely different
 #     multi-flag/multi-value shape (or, for do_fliplabel, an entirely
 #     different command), not a single flag toggle.

--- a/backend/job_registry.py
+++ b/backend/job_registry.py
@@ -195,6 +195,18 @@ _BOOL_CLAUSE_RE = re.compile(
 # rather than risk resolving the wrong thing.
 _BARE_IDENT_RE = re.compile(r'^([A-Za-z_][A-Za-z0-9_]*)$')
 
+# Some jobs guard a command append not on a boolean field's own value but on
+# a plain substring test of a STRING field, via RELION's `FileName::contains`
+# (filename.cpp ~141-148, a bare `rfind(str) > -1` check -- true if the
+# literal appears anywhere in the string). Confirmed for real: Select's
+# `FileName fnt = joboptions["fn_model"].getString(); if
+# (fnt.contains("Class2D/")) { ... if (do_recenter) command += " --recenter
+# "; }` (pipeline_jobs.cpp ~2980-2991) -- do_recenter's flag is only ever
+# emitted when fn_model's value contains "Class2D/" (issue #23).
+_CONTAINS_CLAUSE_RE = re.compile(
+    r'^([A-Za-z_][A-Za-z0-9_]*)\.contains\("([^"]*)"\)$'
+)
+
 
 def _strip_matched_outer_parens(clause: str) -> str:
     """Strip one or more layers of parens that wrap the WHOLE clause (not
@@ -316,9 +328,11 @@ def _evaluate_and_clauses(
     branch is one of the recognized, safely-evaluable shapes: a boolean
     field's own value (optionally negated, as either
     `joboptions["x"].getBoolean()` or the bare local-variable form some
-    jobs use instead -- see _BARE_IDENT_RE), the `is_continue` invariant
-    (a fixed constant in this app -- see below), or `is_tomo`/`!is_tomo`
-    (read from field_values["is_tomo"] when present, see below). Returns
+    jobs use instead -- see _BARE_IDENT_RE), a string field's substring
+    test (optionally negated, as `x.contains("literal")` -- see
+    _CONTAINS_CLAUSE_RE), the `is_continue` invariant (a fixed constant in
+    this app -- see below), or `is_tomo`/`!is_tomo` (read from
+    field_values["is_tomo"] when present, see below). Returns
     None the moment anything else shows up within this branch -- an
     `else` branch marker, a numeric/string comparison, a call this
     function doesn't recognize -- so the caller falls back to marking the
@@ -367,14 +381,21 @@ def _evaluate_and_clauses(
             body = clause[1:].strip() if negated else clause
             m = _BOOL_CLAUSE_RE.match(body)
             if m:
-                ident = m.group(1)
+                value = bool(field_values.get(m.group(1)))
             else:
-                bare = _BARE_IDENT_RE.match(body)
-                if bare and known_keys is not None and bare.group(1) in known_keys:
-                    ident = bare.group(1)
+                contains_m = _CONTAINS_CLAUSE_RE.match(body)
+                if contains_m:
+                    field_name, literal = contains_m.group(1), contains_m.group(2)
+                    if known_keys is not None and field_name in known_keys:
+                        value = literal in str(field_values.get(field_name) or "")
+                    else:
+                        return None
                 else:
-                    return None
-            value = bool(field_values.get(ident))
+                    bare = _BARE_IDENT_RE.match(body)
+                    if bare and known_keys is not None and bare.group(1) in known_keys:
+                        value = bool(field_values.get(bare.group(1)))
+                    else:
+                        return None
             if negated:
                 value = not value
         result = result and value

--- a/backend/tests/test_job_catalog.py
+++ b/backend/tests/test_job_catalog.py
@@ -103,6 +103,11 @@ def test_conditioned_flag_override_exposes_its_condition():
     assert draft_flag_condition_for("Import", "fn_in_other") == "do_other"
 
 
+def test_select_do_recenter_condition_uses_contains_clause():
+    assert draft_flag_for("Select", "do_recenter") == "--recenter"
+    assert draft_flag_condition_for("Select", "do_recenter") == 'fn_model.contains("Class2D/")'
+
+
 def test_negated_flag_override():
     assert draft_flag_for("Class2D", "do_parallel_discio") == "--no_parallel_disc_io"
     assert draft_flag_is_negated("Class2D", "do_parallel_discio") is True

--- a/backend/tests/test_job_registry.py
+++ b/backend/tests/test_job_registry.py
@@ -836,6 +836,9 @@ _UNMAPPED_FIELD_FIXES = [
     ("Postprocess", {"fn_in": "half1.mrc"}, "--i half1.mrc", None),
     ("Postprocess", {"do_skip_fsc_weighting": True}, "--skip_fsc_weighting", None),
     ("Select", {"do_split": True, "do_random": True}, "--random_order", ("do_split", False)),
+    ("Select",
+     {"fn_model": "Class2D/job005/run_it025_optimiser.star", "do_recenter": True},
+     "--recenter", ("do_recenter", False)),
     ("Subtract", {"do_fliplabel": False, "fn_opt": "opt.star"}, "--i opt.star", ("do_fliplabel", True)),
     ("Subtract",
      {"do_fliplabel": False, "do_data": True, "fn_data": "d.star"}, "--data d.star", ("do_data", False)),
@@ -942,6 +945,17 @@ def test_unmapped_field_fix_emits_its_flag(internal_name, on_fields, expect_subs
         )
 
 
+def test_select_do_recenter_requires_class2d_source_regardless_of_its_own_value():
+    raw = job_registry.raw_job("Select")
+    cmd, unmapped = job_registry._build_draft_command(
+        raw,
+        {"fn_model": "Class3D/job006/run_it025_optimiser.star", "do_recenter": True},
+        "Select", "",
+    )
+    assert "--recenter" not in cmd
+    assert "do_recenter" not in unmapped  # correctly omitted, not "can't resolve"
+
+
 def test_jobs_without_a_suffix_entry_keep_the_bare_directory():
     """Most jobs take a plain directory for --o -- e.g. Import, whose
     DRAFT_OVERRIDES entry doesn't set output_suffix -- and must NOT gain an
@@ -1035,6 +1049,21 @@ def test_evaluate_condition(condition, field_values, expected):
     # do_log`, pipeline_jobs.cpp ~2398).
     ("do_refs || do_log", {"do_refs": False, "do_log": True}, {"do_refs", "do_log"}, True),
     ("do_refs || do_log", {"do_refs": False, "do_log": False}, {"do_refs", "do_log"}, False),
+    # A string field's substring test via `.contains("literal")" -- RELION's
+    # own FileName::contains is a plain rfind-based substring search
+    # (filename.cpp ~141-148). Confirmed for real: Select's `FileName fnt =
+    # joboptions["fn_model"].getString(); if (fnt.contains("Class2D/"))
+    # { ... }` (pipeline_jobs.cpp ~2980-2991, issue #23).
+    ('fn_model.contains("Class2D/")', {"fn_model": "Class2D/job005/run_it025_optimiser.star"},
+     {"fn_model"}, True),
+    ('fn_model.contains("Class2D/")', {"fn_model": "Class3D/job006/run_it025_optimiser.star"},
+     {"fn_model"}, False),
+    ('!fn_model.contains("Class2D/")', {"fn_model": "Class2D/job005/run_it025_optimiser.star"},
+     {"fn_model"}, False),
+    ('fn_model.contains("Class2D/")', {"fn_model": "Class2D/job005/run_it025_optimiser.star"},
+     set(), None),
+    ('fn_model.contains("Class2D/")', {"fn_model": "Class2D/job005/run_it025_optimiser.star"},
+     None, None),
 ])
 def test_evaluate_condition_bare_identifier(condition, field_values, known_keys, expected):
     assert job_registry._evaluate_condition(condition, field_values, known_keys) is expected


### PR DESCRIPTION
## Summary
- `Select.do_recenter` was completely unmapped: RELION's `getCommandsSelectJob` only appends `--recenter` when `do_recenter` is checked AND the input `fn_model` path contains the literal `"Class2D/"` (`pipeline_jobs.cpp` ~2977-2991, via `FileName::contains`, a plain substring `rfind` check confirmed in `filename.cpp` ~141-148).
- `_evaluate_and_clauses`/`_evaluate_condition` in `backend/job_registry.py` had no way to express a string-field substring test — only `is_continue`/`is_tomo`/boolean-field clauses were recognized. Added a new `field.contains("literal")` clause shape (`_CONTAINS_CLAUSE_RE`), safe-gated behind `known_keys` exactly like the existing bare-identifier clause.
- Wired this up in `backend/job_catalog.py`'s `DRAFT_OVERRIDES["Select"]`: `do_recenter` now carries `condition='fn_model.contains("Class2D/")'`; `do_recenter`'s own boolean value is still handled automatically by the normal boolean-field emit path.
- Removed the now-stale `Select.do_recenter` mention from the "Deliberately NOT included" comment block (kept the rest of that sentence intact).

Fixes #23

## Test plan
- [x] Added 5 new parametrize cases to `test_evaluate_condition_bare_identifier` covering the `.contains()` clause (true/false/negated, and the `known_keys` safety-rail cases).
- [x] Added a `Select` row to `_UNMAPPED_FIELD_FIXES` verifying `--recenter` appears/disappears with `do_recenter`.
- [x] Added `test_select_do_recenter_requires_class2d_source_regardless_of_its_own_value`, isolating the `fn_model`-side gate.
- [x] Added `test_select_do_recenter_condition_uses_contains_clause` in `test_job_catalog.py`.
- [x] Full backend suite: `749 passed` (up from a 741 baseline), zero regressions.
- [x] Manual verification: `--recenter` appears when `fn_model` contains `"Class2D/"` and `do_recenter=True`; absent when `fn_model` is a `Class3D/...` path even with `do_recenter=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)