### PR TITLE
Fix Ctfrefine's do_ctf/do_tilt/do_aniso_mag kmin values and fit_mode string

### DIFF
--- a/backend/job_catalog.py
+++ b/backend/job_catalog.py
@@ -713,6 +713,59 @@ def _extract_extra_flags(field_values: dict) -> list:
     return _extract_bg_radius_flags(field_values) + _extract_helical_nr_asu_rise_fallback_flags(field_values)
 
 
+_CTF_FIT_LETTER = {"No": "f", "Per-micrograph": "m", "Per-particle": "p"}
+# JobOption::getCtfFitString (src/pipeline_jobs.cpp ~243-249): the exact
+# label->single-character mapping RELION's own getCommandsCtfrefineJob
+# uses to build --fit_mode. An unrecognized label (a future RELION version
+# renaming a choice) resolves to None below, not a wrong guess.
+
+
+def _ctfrefine_kmin_and_fit_mode_flags(field_values: dict) -> list:
+    """Ctfrefine's do_aniso_mag/do_ctf/do_tilt branch (getCommandsCtfrefineJob
+    ~6116-6151, confirmed current): each toggle's own self-contained flag
+    is a plain FlagOverride (see the Ctfrefine DRAFT_OVERRIDES entry
+    below) -- this covers the companion VALUE each one unconditionally
+    appends, all three built from the SAME "minres" field under a
+    different flag name, plus do_ctf's --fit_mode (four radio fields
+    concatenated via JobOption::getCtfFitString, in the exact order
+    phase/defocus/astig/"f" (Cs, fixed off)/bfactor -- getting this order
+    wrong silently produces a wrong-but-plausible 5-character mode
+    string). do_ctf and do_tilt are independent siblings inside the
+    !do_aniso_mag else-branch (NOT else-if) -- both can fire at once, each
+    appending its own kmin_* value. minres/do_phase/do_defocus/do_astig/
+    do_bfactor are suppressed (see the DRAFT_OVERRIDES entry) -- fully
+    expressed here instead, since none of them has one single owning
+    flag. minres is parsed with _safe_float rather than passed through
+    raw: extra_flags' output is appended to the draft command unquoted
+    (job_registry._build_draft_command extends parts directly, unlike the
+    shlex.quote'd generic per-option path), so a raw pass-through of an
+    un-vetted field value could smuggle extra whitespace-separated tokens
+    into the command; a clean float formats back to a plain numeral with
+    no such risk."""
+    minres = _safe_float(field_values.get("minres"), None)
+    has_minres = minres is not None
+    out: list = []
+    if field_values.get("do_aniso_mag"):
+        if has_minres:
+            out += ["--kmin_mag", str(minres)]
+        return out
+    if field_values.get("do_ctf"):
+        if has_minres:
+            out += ["--kmin_defocus", str(minres)]
+        letters = [
+            _CTF_FIT_LETTER.get(field_values.get("do_phase")),
+            _CTF_FIT_LETTER.get(field_values.get("do_defocus")),
+            _CTF_FIT_LETTER.get(field_values.get("do_astig")),
+            "f",
+            _CTF_FIT_LETTER.get(field_values.get("do_bfactor")),
+        ]
+        if all(letter is not None for letter in letters):
+            out += ["--fit_mode", "".join(letters)]
+    if field_values.get("do_tilt") and has_minres:
+        out += ["--kmin_tilt", str(minres)]
+    return out
+
+
 DRAFT_OVERRIDES: dict[str, JobDraftOverride] = {
     # getCommandsTomoImportJob, DEFAULT branch (do_coords == false):
     #   command = "relion_python_tomo_import SerialEM ..."
@@ -1382,19 +1435,22 @@ DRAFT_OVERRIDES: dict[str, JobDraftOverride] = {
     ),
     "Ctfrefine": JobDraftOverride(
         flags={
-            # `if (do_tilt) { ... if (do_trefoil) command += "
-            # --odd_aberr_max_n 3"; }` (~6142) -- only the self-contained
-            # inner flag; do_tilt/do_ctf themselves each also unconditionally
-            # append a companion VALUE (--kmin_tilt/--kmin_defocus + minres,
-            # a field shared across three differently-named flags depending
-            # on which branch is active) that this table has no way to
-            # express, so they stay unmapped for hand-editing.
+            # `if (do_aniso_mag) { --fit_aniso; --kmin_mag <minres>; } else
+            # { if (do_ctf) {...} if (do_tilt) {...} }` (~6116-6151) --
+            # each toggle's own self-contained flag; the companion
+            # --kmin_*/--fit_mode VALUES built from minres/do_phase/
+            # do_defocus/do_astig/do_bfactor need real branch logic none
+            # of FlagOverride/value_transforms/numeric_transforms can
+            # express alone -- see _ctfrefine_kmin_and_fit_mode_flags
+            # above (issue #20).
+            "do_aniso_mag": FlagOverride("--fit_aniso"),
+            "do_ctf": FlagOverride("--fit_defocus", condition="!do_aniso_mag"),
+            "do_tilt": FlagOverride("--fit_beamtilt", condition="!do_aniso_mag"),
             "do_trefoil": FlagOverride("--odd_aberr_max_n 3", condition="do_tilt"),
-            # `if (!do_aniso_mag) { ... if (do_4thorder) command += "
-            # --fit_aberr"; }` (~6148, inside the else of the do_aniso_mag
-            # branch at ~6100).
             "do_4thorder": FlagOverride("--fit_aberr", condition="!do_aniso_mag"),
         },
+        suppress=frozenset({"minres", "do_phase", "do_defocus", "do_astig", "do_bfactor"}),
+        extra_flags=_ctfrefine_kmin_and_fit_mode_flags,
     ),
 }
 # Deliberately NOT included above (mode-branched or otherwise not safely
@@ -1407,10 +1463,6 @@ DRAFT_OVERRIDES: dict[str, JobDraftOverride] = {
 #     pipeline_jobs.cpp ~3993-4000, ~4482-4499, ~4754-4763, ~2314-2321) --
 #     a real value TRANSFORM, not just a lookup, so a wrong guess risks a
 #     subtly incorrect run rather than a loud crash.
-#   - Ctfrefine.do_defocus/do_astig/do_bfactor/do_phase ("No"/"Per-
-#     micrograph"/"Per-particle" -> single-letter codes concatenated into one
-#     --fit_defocus-style flag via JobOption::getCtfFitString,
-#     pipeline_jobs.cpp ~243-249).
 #   - Joinstar's output suffix depends on which of fn_part/fn_mic/fn_mov is
 #     filled in (src/pipeline_jobs.cpp ~5069/5103/5137).
 #   - Localres only appends "relion" in the do_relion_locres branch; the
@@ -1437,11 +1489,6 @@ DRAFT_OVERRIDES: dict[str, JobDraftOverride] = {
 #     use a plain boolean gate instead and ARE fixed), and Autopick's
 #     do_pick_helical_segments-gated --min_distance (helical_nr_asu *
 #     helical_rise, a genuine multiply this table can't express).
-#   - Ctfrefine.do_ctf/do_tilt/do_aniso_mag: each unconditionally appends a
-#     companion VALUE right after its own flag (--kmin_defocus/--kmin_tilt/
-#     --kmin_mag, all built from the SAME "minres" field under a different
-#     flag name per branch) -- only their self-contained inner children
-#     (do_trefoil, do_4thorder) were safe to add on their own.
 #   - Extract.do_norm/bg_diameter/do_extract_helix family: bg_radius is
 #     computed (diameter->radius, extract_size- and do_rescale-dependent,
 #     ~2584-2600); the helix branch hardcodes "--helical_nr_asu 1

--- a/backend/tests/test_job_catalog.py
+++ b/backend/tests/test_job_catalog.py
@@ -229,6 +229,29 @@ def test_extra_flags_extract_helical_fallback_absent_once_cutting_into_segments(
     ) == []
 
 
+def test_extra_flags_ctfrefine_aniso_mag_kmin():
+    assert draft_extra_flags("Ctfrefine", {"do_aniso_mag": True, "minres": 25.0}) == \
+        ["--kmin_mag", "25.0"]
+
+
+def test_extra_flags_ctfrefine_do_ctf_kmin_and_fit_mode():
+    assert draft_extra_flags("Ctfrefine", {
+        "do_aniso_mag": False, "do_ctf": True, "minres": 25.0,
+        "do_phase": "No", "do_defocus": "Per-particle", "do_astig": "No", "do_bfactor": "No",
+    }) == ["--kmin_defocus", "25.0", "--fit_mode", "fpfff"]
+
+
+def test_extra_flags_ctfrefine_unknown_fit_label_omits_fit_mode_not_crash():
+    assert draft_extra_flags("Ctfrefine", {
+        "do_aniso_mag": False, "do_ctf": True, "minres": 25.0,
+        "do_phase": "some future label", "do_defocus": "No", "do_astig": "No", "do_bfactor": "No",
+    }) == ["--kmin_defocus", "25.0"]
+
+
+def test_extra_flags_ctfrefine_all_off_returns_nothing():
+    assert draft_extra_flags("Ctfrefine", {"do_aniso_mag": False, "do_ctf": False, "do_tilt": False}) == []
+
+
 def test_extra_flags_default_job_returns_nothing():
     assert draft_extra_flags("Motioncorr", {}) == []
 

--- a/backend/tests/test_job_registry.py
+++ b/backend/tests/test_job_registry.py
@@ -804,6 +804,22 @@ _UNMAPPED_FIELD_FIXES = [
     ("TomoCtffind", {"slow_search": False}, "--fast_search", ("slow_search", True)),
     ("Ctfrefine", {"do_tilt": True, "do_trefoil": True}, "--odd_aberr_max_n 3", ("do_tilt", False)),
     ("Ctfrefine", {"do_aniso_mag": False, "do_4thorder": True}, "--fit_aberr", ("do_aniso_mag", True)),
+    ("Ctfrefine", {"do_aniso_mag": True, "minres": 25.0}, "--fit_aniso", None),
+    ("Ctfrefine", {"do_aniso_mag": True, "minres": 25.0}, "--kmin_mag 25.0", ("do_aniso_mag", False)),
+    ("Ctfrefine",
+     {"do_aniso_mag": False, "do_ctf": True, "minres": 25.0,
+      "do_phase": "No", "do_defocus": "Per-particle", "do_astig": "No", "do_bfactor": "No"},
+     "--fit_defocus", ("do_aniso_mag", True)),
+    ("Ctfrefine",
+     {"do_aniso_mag": False, "do_ctf": True, "minres": 25.0,
+      "do_phase": "No", "do_defocus": "Per-particle", "do_astig": "No", "do_bfactor": "No"},
+     "--kmin_defocus 25.0", ("do_ctf", False)),
+    ("Ctfrefine",
+     {"do_aniso_mag": False, "do_ctf": True, "minres": 25.0,
+      "do_phase": "No", "do_defocus": "Per-particle", "do_astig": "No", "do_bfactor": "No"},
+     "--fit_mode fpfff", ("do_ctf", False)),
+    ("Ctfrefine", {"do_aniso_mag": False, "do_tilt": True, "minres": 12.0},
+     "--kmin_tilt 12.0", ("do_tilt", False)),
     ("Extract", {"do_reextract": True, "do_reset_offsets": True}, "--reset_offsets", ("do_reextract", False)),
     ("Extract", {"do_reextract": True, "do_recenter": True}, "--recenter", ("do_reextract", False)),
     ("Extract", {"do_invert": True}, "--invert_contrast", None),
@@ -1182,6 +1198,34 @@ def test_extract_norm_flag_survives_even_when_bg_radius_cant_be_computed():
         assert "--bg_radius" not in cmd, (bad_extract_size, cmd)
         assert "do_norm" not in unmapped
     assert not any(k in unmapped for k in ("do_norm", "bg_diameter"))
+
+
+def test_ctfrefine_do_ctf_and_do_tilt_both_true_each_get_their_own_kmin():
+    """do_ctf and do_tilt are independent siblings (not else-if) inside the
+    !do_aniso_mag branch -- both can be true at once, each appending its
+    OWN --kmin_* built from the SAME minres field under a different flag
+    name (getCommandsCtfrefineJob ~6127-6146, confirmed current)."""
+    raw = job_registry.raw_job("Ctfrefine")
+    fields = {
+        "do_aniso_mag": False, "do_ctf": True, "do_tilt": True, "minres": 15.0,
+        "do_phase": "No", "do_defocus": "No", "do_astig": "No", "do_bfactor": "No",
+    }
+    cmd, unmapped = job_registry._build_draft_command(raw, fields, "Ctfrefine", "")
+    assert "--kmin_defocus 15.0" in cmd
+    assert "--kmin_tilt 15.0" in cmd
+    assert "--fit_mode fffff" in cmd
+    assert "--kmin_mag" not in cmd
+    assert not any(k in unmapped for k in ("minres", "do_phase", "do_defocus", "do_astig", "do_bfactor"))
+
+
+def test_ctfrefine_do_aniso_mag_suppresses_do_ctf_and_do_tilt_kmin():
+    raw = job_registry.raw_job("Ctfrefine")
+    fields = {"do_aniso_mag": True, "do_ctf": True, "do_tilt": True, "minres": 20.0}
+    cmd, _ = job_registry._build_draft_command(raw, fields, "Ctfrefine", "")
+    assert "--kmin_mag 20.0" in cmd
+    assert "--kmin_defocus" not in cmd
+    assert "--kmin_tilt" not in cmd
+    assert "--fit_mode" not in cmd
 
 
 def test_extract_helical_nr_asu_rise_fallback_is_mutually_exclusive_with_the_real_values():


### PR DESCRIPTION
## Summary
- `Ctfrefine`'s `do_ctf`/`do_tilt`/`do_aniso_mag` were completely unmapped: each unconditionally appends a companion `--kmin_defocus`/`--kmin_tilt`/`--kmin_mag` value built from the shared `minres` field, and `do_ctf` also builds `--fit_mode` by concatenating four radio fields (phase/defocus/astig/Cs-always-off/bfactor) via RELION's `JobOption::getCtfFitString` letter mapping (`"No"→"f"`, `"Per-micrograph"→"m"`, `"Per-particle"→"p"`) — none of this was previously mapped, so drafts for these branches silently omitted required values.
- Adds a job-level `extra_flags` hook (`_ctfrefine_kmin_and_fit_mode_flags` in `backend/job_catalog.py`) that replays the real branch logic from `getCommandsCtfrefineJob` (`src/pipeline_jobs.cpp` ~6116-6151): `do_ctf` and `do_tilt` are independent siblings inside the `!do_aniso_mag` branch (not `else if`), so both can fire at once, each appending its own `kmin_*`.
- Suppresses `minres`/`do_phase`/`do_defocus`/`do_astig`/`do_bfactor` from the generic per-option loop (fully handled by the new hook instead), and parses `minres` through the existing `_safe_float` helper rather than a raw pass-through, since `extra_flags` output is appended to the draft command unquoted.
- Removes the two now-stale "deliberately not included" comment bullets that described this exact gap.

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('backend/job_catalog.py').read())"` — syntax check passes
- [x] Manual verification script (do_ctf + do_tilt both on) produces `--kmin_defocus 15.0 --fit_mode fffff --kmin_tilt 15.0` with zero unmapped fields
- [x] `cd backend && python3 -m pytest tests/ -q` — 753 passed (was 741 baseline before this change), zero regressions
- [x] Added targeted unit tests in `test_job_registry.py` (6 parametrized rows + 2 dedicated tests covering the do_ctf+do_tilt-both-true sibling case and the do_aniso_mag-suppresses-the-others case) and `test_job_catalog.py` (4 tests on `draft_extra_flags` directly, including an unknown-fit-label-doesn't-crash case)
- [x] Ran `code-review` skill; fixed the one finding (raw `minres` pass-through into an unquoted extra_flags token — now parsed via `_safe_float` first)

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)