### PR TITLE
Fix #44: document free_port()'s check-then-bind race in run_tests.sh

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -95,6 +95,28 @@ trap cleanup EXIT INT TERM
 # ---------------------------------------------------------------------------
 
 free_port() {
+  # KNOWN RACE (check-then-bind, not fixed here -- see issue #44):
+  # this probes each candidate port by binding then immediately closing it,
+  # so the port is free again the instant this function returns. The real
+  # bind doesn't happen until start_backend() execs uvicorn, which is well
+  # after this returns -- project-fixture setup, stub-bin creation, etc. --
+  # a real gap of dozens of lines and meaningful wall-clock time, not a
+  # tight race window. Two run_tests.sh invocations on the same host,
+  # started close enough together, could both see the same port as
+  # momentarily free and race to claim it.
+  #
+  # This is accepted as low-risk for now because run_tests.sh is used
+  # sequentially/locally (one dev, one invocation at a time) and is not
+  # part of any concurrent CI matrix on a shared host; a losing uvicorn
+  # would just fail to bind and start_backend()'s readiness poll would
+  # time out with a clear log, not corrupt state silently.
+  #
+  # A real fix can't be done inside this function alone: it would need
+  # start_backend() (the caller, defined later in this file) to either
+  # hold this same socket open (e.g. via SO_REUSEADDR/SO_REUSEPORT) until
+  # right before the `exec uvicorn ...` call, or retry free_port() when
+  # the uvicorn exec itself fails to bind -- both require changes on the
+  # caller side, which is out of scope for this fix.
   local port=$PORT_BASE
   while "$PYTHON" - "$port" <<'PY' 2>/dev/null
 import socket, sys


### PR DESCRIPTION
## Summary
- `free_port()` in `run_tests.sh` binds and immediately closes a socket to probe port availability, but the real bind doesn't happen until `start_backend()` execs uvicorn much later -- a real gap of dozens of lines and meaningful wall-clock time (project-fixture setup, stub-bin creation, etc.), not a tight window. Two concurrent `run_tests.sh` invocations on the same host could race to claim the same port.
- A real structural fix requires cooperation from the caller (`start_backend()`) -- e.g. holding the probe socket open until right before the uvicorn exec, or retrying on bind failure -- which is out of scope for a change confined to `free_port()`'s own body (per this batch's merge-conflict-avoidance constraints, two other in-flight units also touch `run_tests.sh` elsewhere).
- Per issue #44's own guidance, documented the race directly in `free_port()`: what it is, why it's accepted as low-risk for how this script is actually used (sequential/local test runs, not a concurrent CI matrix on a shared host), and what a real fix would need to change in the caller.
- No behavior change -- comment-only addition.

## Test plan
- [x] `bash -n run_tests.sh` -- syntax check passes
- [x] `python -m pytest -q` in `backend/` -- 868 passed
- [x] `./run_tests.sh` (default tier) run twice in a row -- both show "All selected suites passed." with no port-related failures
- [x] `git diff run_tests.sh` confirmed confined to `free_port()`'s own body; no other file touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)