### PR TITLE
Fix #41: document verify_draft_flags_against_relion.py in run_tests.sh

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -59,6 +59,11 @@
 #   RELION_US_PYTHON    python to use (default: python3)
 #   RELION_US_CHROMIUM  chromium binary, if Playwright's own is not usable
 #   RELION_US_PORT_BASE first port to allocate from (default: 8500)
+#
+# Not run by any tier here: backend/tests/verify_draft_flags_against_relion.py
+# checks DRAFT_OVERRIDES's flags against a real, locally-installed RELION
+# (RELION_BIN_DIR, RELION_SRC_DIR) -- run it by hand after a RELION upgrade:
+#   python3 backend/tests/verify_draft_flags_against_relion.py
 
 set -uo pipefail
 


### PR DESCRIPTION
## Summary
- `backend/tests/verify_draft_flags_against_relion.py` is a well-designed drift-detector for `DRAFT_OVERRIDES` in `job_catalog.py`, deliberately kept out of pytest collection and out of any `run_tests.sh` tier since it needs a real, locally-installed RELION.
- It was undiscoverable from `run_tests.sh`, the file a maintainer actually checks to answer "how do I run the checks here."
- Added a short note to the `Environment:` comment block documenting the exact manual invocation (`python3 backend/tests/verify_draft_flags_against_relion.py`) and the `RELION_BIN_DIR`/`RELION_SRC_DIR` env vars it reads, matching the terse style of the surrounding comment.
- No new tier added, per the issue's own suggested "simpler" fix, to avoid overlapping two other in-flight units also editing `run_tests.sh` (`free_port()` and `add_analyze_classification_run()`).

## Test plan
- [x] `bash -n run_tests.sh` — syntax OK
- [x] `python -m pytest -q` in `backend/` — 868 passed
- [x] `./run_tests.sh` (default tier) — "All selected suites passed."
- [x] `git diff run_tests.sh` confirmed change confined to the `Environment:` comment block only

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)