### PR TITLE
Add custom browser UI for Exclude Tilt Images

### DIFF
--- a/backend/custom_jobs.py
+++ b/backend/custom_jobs.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+import exclude_tilts
 import job_registry
 import manual_pick
 import viz
@@ -58,30 +59,35 @@ def _opt_float(value) -> float | None:
 
 
 def _picker_definition(internal_name: str, real_job_name: str, label_new: str,
-                        display_name: str, description: str, picker_kind: str) -> dict:
-    """Manualpick/TomoManualPick reuse the REAL RELION option list/layout
-    (job_registry.raw_job(real_job_name), still present in
-    data/job_definitions_raw.json even though job_catalog.JOB_CATALOG no
-    longer lists Manualpick as a real subprocess job -- see job_catalog.py's
-    CUSTOM_JOBS docstring) rather than hand-picking a subset. That keeps the
-    Inputs tab identical to what real RELION's own GUI would show for the
-    same job type, which is what makes the job.star this ultimately
-    registers (see run_manual_pick/run_tomo_manual_pick below) a genuinely
-    realistic one -- every field a real relion_manualpick/
-    relion_python_tomo_pick job would have, not just the handful this app's
-    own picker actually uses.
+                        display_name: str, description: str, picker_kind: str,
+                        category: str = "Particle Picking",
+                        action_desc: str = "picking happens",
+                        impl_module: str = "backend/manual_pick.py") -> dict:
+    """Manualpick/TomoManualPick/TomoExcludeTiltImages all reuse the REAL
+    RELION option list/layout (job_registry.raw_job(real_job_name), still
+    present in data/job_definitions_raw.json even though job_catalog.
+    JOB_CATALOG no longer lists any of them as a real subprocess job -- see
+    job_catalog.py's CUSTOM_JOBS docstring) rather than hand-picking a
+    subset. That keeps the Inputs tab identical to what real RELION's own
+    GUI would show for the same job type, which is what makes the job.star
+    this ultimately registers (see run_manual_pick/run_tomo_manual_pick/
+    run_exclude_tilt_images below) a genuinely realistic one -- every field
+    a real relion_manualpick/relion_python_tomo_pick/relion_tomo_exclude_
+    tilt_images job would have, not just the handful this app's own in-
+    browser UI actually uses.
 
-    picker_kind ("spa" | "tomo") tags the popup so app.js knows to show the
-    Picker button/embedded viewer instead of (custom jobs') plain Run
-    button, and which manual_pick.py functions + /api/manual-pick/* routes
-    to call.
+    picker_kind ("spa" | "tomo" | "excludetilts") tags the popup so app.js
+    knows to show the Picker button/embedded UI instead of (custom jobs')
+    plain Run button, which in-browser UI to open (the orthoslice picker
+    for spa/tomo, the tilt-image reviewer for excludetilts), and which
+    input field names/API routes to call for it.
     """
     raw = job_registry.raw_job(real_job_name)
     return {
         "internal_name": internal_name,
         "label_new": label_new,
         "display_name": display_name,
-        "category": "Particle Picking",
+        "category": category,
         "description": description,
         "options": raw.get("options", []),
         "standard_groups": job_registry._standard_groups(raw),
@@ -91,7 +97,7 @@ def _picker_definition(internal_name: str, real_job_name: str, label_new: str,
         # these two), so anything set here would be dead and misleadingly
         # imply otherwise.
         "program_guess": (
-            f"(no subprocess -- see backend/manual_pick.py; picking happens in "
+            f"(no subprocess -- see {impl_module}; {action_desc} in "
             f"the in-browser viewer, not {raw.get('program_guess', 'the real binary')})"
         ),
         "flags_used": [],
@@ -110,6 +116,13 @@ CUSTOM_JOB_DEFINITIONS = {
     "TomoManualPick": _picker_definition(
         "TomoManualPick", "TomoPickTomograms", "relion.picktomo", "Manual Picking (Tomo)",
         "Manually pick particles in tomograms", "tomo",
+    ),
+    "TomoExcludeTiltImages": _picker_definition(
+        "TomoExcludeTiltImages", "TomoExcludeTiltImages", "relion.excludetilts",
+        "Exclude Tilt Images", "Exclusion of bad tilt-images from tilt-series", "excludetilts",
+        category="Tilt Series / Tomogram Reconstruction",
+        action_desc="tilt-image review/exclusion happens",
+        impl_module="backend/exclude_tilts.py",
     ),
     "ImodImport": {
         "internal_name": "ImodImport",
@@ -399,9 +412,47 @@ async def run_tomo_manual_pick(project_dir: Path, values: dict, job_dir: Path) -
     return await asyncio.to_thread(work)
 
 
+async def run_exclude_tilt_images(project_dir: Path, values: dict, job_dir: Path) -> str:
+    """Tilt-image-exclusion counterpart of run_manual_pick/run_tomo_manual_
+    pick above -- same stays_running / Done / Continue / Overwrite-clears-
+    first reasoning (see run_manual_pick's docstring).
+
+    Unlike picking, there's an obvious non-destructive default with nothing
+    chosen yet: keep EVERY tilt image (relion_tomo_exclude_tilt_images' own
+    napari widget starts the exact same way -- nothing pre-excluded until
+    the user acts on it). So, unlike an unpicked SPA/tomo job (which has
+    literally no particles yet), this writes that full pass-through
+    immediately (exclude_tilts.write_passthrough) rather than leaving the
+    job's output missing until the user opens the reviewer -- the job's
+    output (selected_tilt_series.star) stays valid for downstream jobs
+    (Reconstruct Tomograms, TomoSubtomo, ...) to read even if the reviewer
+    is never opened at all.
+    """
+    in_tiltseries = values.get("in_tiltseries", "")
+    if not in_tiltseries:
+        raise ValueError("Input tilt series field is required.")
+
+    def work():
+        removed = exclude_tilts.clear_exclusions(job_dir)
+        n_series = exclude_tilts.write_passthrough(project_dir, job_dir, in_tiltseries)
+        cleared_note = f"Cleared {removed} existing output file(s) from a previous run.\n" if removed else ""
+        return (
+            f"{cleared_note}"
+            f"Found {n_series} tilt series in {in_tiltseries}.\n"
+            f"Every tilt image is kept by default -- 'nothing excluded' is a "
+            f"legitimate choice on its own. Use the Picker button above to "
+            f"review each tilt series and exclude bad images -- this job's "
+            f"output (selected_tilt_series.star) stays valid for downstream "
+            f"jobs (Reconstruct Tomograms, TomoSubtomo, ...) to read either way."
+        )
+
+    return await asyncio.to_thread(work)
+
+
 CUSTOM_JOB_RUNNERS = {
     "Manualpick": run_manual_pick,
     "TomoManualPick": run_tomo_manual_pick,
+    "TomoExcludeTiltImages": run_exclude_tilt_images,
     "ImodImport": run_imod_import,
     "WarpImport": run_warp_import,
     "DeepETPickerImport": run_deepetpicker_import,

--- a/backend/custom_jobs.py
+++ b/backend/custom_jobs.py
@@ -433,8 +433,7 @@ async def run_exclude_tilt_images(project_dir: Path, values: dict, job_dir: Path
         raise ValueError("Input tilt series field is required.")
 
     def work():
-        removed = exclude_tilts.clear_exclusions(job_dir)
-        n_series = exclude_tilts.write_passthrough(project_dir, job_dir, in_tiltseries)
+        removed, n_series = exclude_tilts.reset_and_write_passthrough(project_dir, job_dir, in_tiltseries)
         cleared_note = f"Cleared {removed} existing output file(s) from a previous run.\n" if removed else ""
         return (
             f"{cleared_note}"

--- a/backend/exclude_tilts.py
+++ b/backend/exclude_tilts.py
@@ -41,6 +41,7 @@ user opens the reviewer at all.
 from __future__ import annotations
 
 import re
+import threading
 from pathlib import Path
 from typing import Optional
 
@@ -74,6 +75,30 @@ class ExcludeTiltsError(Exception):
     the API turns this into a 400."""
 
 
+# Per-job_dir lock guarding every function below that reads-then-writes this
+# job's own output files (write_passthrough, clear_exclusions,
+# save_tilt_series_exclusions). Job start (custom_jobs.run_exclude_tilt_
+# images, via asyncio.to_thread) and a save/overwrite request from the
+# browser (main.py's plain `def` endpoints, which FastAPI already runs in
+# its own threadpool) can genuinely run concurrently on separate threads --
+# without this, one could delete/overwrite files the other is mid-read on
+# (e.g. clear_exclusions unlinking selected_tilt_series.star while a save's
+# _upsert_job_global_star is reading it), corrupting or losing other tilt
+# series' already-saved state.
+_JOB_LOCKS: dict[str, threading.Lock] = {}
+_JOB_LOCKS_GUARD = threading.Lock()
+
+
+def _job_lock(job_dir: Path) -> threading.Lock:
+    key = str(Path(job_dir).resolve())
+    with _JOB_LOCKS_GUARD:
+        lock = _JOB_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _JOB_LOCKS[key] = lock
+        return lock
+
+
 def _sanitize(name: str) -> str:
     """A tilt series name, made safe as a flat filename fragment -- same
     rule as manual_pick._sanitize_relpath, kept collision-free even though
@@ -84,7 +109,13 @@ def _sanitize(name: str) -> str:
 def _read_star_blocks(path: Path) -> dict:
     import starfile
 
-    return starfile.read(path, always_dict=True)
+    # rlnTomoName is often purely numeric (e.g. "01") in real tutorial
+    # datasets -- without this, starfile/pandas infers it as an int column,
+    # silently corrupting any name with a leading zero or non-numeric
+    # variant on round-trip (confirmed against a real CtfFind tilt_series_
+    # ctf.star: rlnTomoName values like "TS_01" survive, but a purely
+    # numeric project's "01" would come back as 1).
+    return starfile.read(path, always_dict=True, parse_as_string=[GLOBAL_TOMO_NAME_COL])
 
 
 def _read_global_table(project_dir: Path, in_tiltseries: str):
@@ -158,50 +189,88 @@ def _read_job_series(job_dir: Path, tomo_name: str):
 def _write_series_output(project_dir: Path, job_dir: Path, tomo_name: str, global_row, df) -> Path:
     """Write one tilt series' own STAR (the block-name/filename convention a
     real relion_tomo_exclude_tilt_images run produces: data_<TomoName>, at
-    <job_dir>/tilt_series/<TomoName>.star) and upsert this tomogram's row in
-    the job-level selected_tilt_series.star (data_global), pointing at the
-    file just written rather than the original input's copy."""
+    <job_dir>/tilt_series/<TomoName>.star) -- ALWAYS, even with zero rows
+    (an empty per-image STAR is what tells _read_job_series/list_images this
+    series has been explicitly fully excluded, as opposed to never touched
+    at all) -- and update this tomogram's row in the job-level
+    selected_tilt_series.star (data_global). A fully-excluded series is
+    DROPPED from that global table rather than kept with zero rows, matching
+    real RELION's own RlnTiltSeriesSet.write_star_file convention (a
+    downstream job like Reconstruct Tomograms has nothing to do with a tilt
+    series that has no images left)."""
     import starfile
 
     job_dir = Path(job_dir)
     series_path = _job_series_path(job_dir, tomo_name)
     series_path.parent.mkdir(parents=True, exist_ok=True)
     starfile.write({tomo_name: df.reset_index(drop=True)}, series_path, overwrite=True)
-    _upsert_job_global_star(project_dir, job_dir, tomo_name, global_row, series_path)
+    if len(df) > 0:
+        _upsert_job_global_star(project_dir, job_dir, tomo_name, global_row, series_path)
+    else:
+        _remove_from_job_global_star(job_dir, tomo_name)
     return series_path
 
 
-def _upsert_job_global_star(project_dir: Path, job_dir: Path, tomo_name: str, global_row, series_path: Path) -> None:
-    import starfile
-
+def _load_job_global_rows(job_dir: Path) -> dict:
+    """This job's own already-written selected_tilt_series.star, as
+    {tomo_name: row_dict}. A read failure (missing/corrupt file, unexpected
+    shape) is NOT swallowed here -- letting it propagate is safer than
+    silently returning {}, which would make the caller's next write discard
+    every other tilt series' already-saved row (confirmed for real:
+    write_passthrough's loop wrote only the LAST series processed, before
+    this was ever guarded, because a broad `except Exception` reset the
+    whole accumulator on any hiccup)."""
     job_dir = Path(job_dir)
     job_star = job_dir / JOB_GLOBAL_STAR_NAME
     rows: dict[str, dict] = {}
     if job_star.is_file():
-        try:
-            blocks = _read_star_blocks(job_star)
-            # NOT `blocks.get(...) or next(...)` -- a DataFrame's truthiness
-            # is ambiguous (raises ValueError), which the except below would
-            # silently swallow, resetting `rows` to {} and losing every
-            # OTHER tilt series' row already written (confirmed for real:
-            # write_passthrough's loop wrote only the LAST series processed
-            # before this fix, discarding the rest on each subsequent call).
-            existing = blocks.get(JOB_GLOBAL_BLOCK_NAME)
-            if existing is None:
-                existing = next(iter(blocks.values()), None)
-            if existing is not None and GLOBAL_TOMO_NAME_COL in existing.columns:
-                for _, r in existing.iterrows():
-                    rows[str(r[GLOBAL_TOMO_NAME_COL])] = r.to_dict()
-        except Exception:  # noqa: BLE001
-            rows = {}
+        blocks = _read_star_blocks(job_star)
+        existing = blocks.get(JOB_GLOBAL_BLOCK_NAME)
+        if existing is None:
+            existing = next(iter(blocks.values()), None)
+        if existing is not None and GLOBAL_TOMO_NAME_COL in existing.columns:
+            for _, r in existing.iterrows():
+                rows[str(r[GLOBAL_TOMO_NAME_COL])] = r.to_dict()
+    return rows
 
+
+def _write_job_global_rows(job_dir: Path, rows: dict) -> None:
+    import starfile
+
+    job_star = Path(job_dir) / JOB_GLOBAL_STAR_NAME
+    if not rows:
+        # No tilt series has any kept image left -- nothing for a
+        # downstream job to read. Drop the file rather than writing a
+        # column-less STAR (there is no schema left to derive columns
+        # from once every row is gone).
+        if job_star.is_file():
+            job_star.unlink()
+        return
+    df = pd.DataFrame(list(rows.values()))
+    starfile.write({JOB_GLOBAL_BLOCK_NAME: df}, job_star, overwrite=True)
+
+
+def _upsert_job_global_star(project_dir: Path, job_dir: Path, tomo_name: str, global_row, series_path: Path) -> None:
+    rows = _load_job_global_rows(job_dir)
     new_row = global_row.to_dict()
     new_row[GLOBAL_TOMO_NAME_COL] = str(tomo_name)
     new_row[GLOBAL_STARFILE_COL] = str(series_path.relative_to(project_dir))
     rows[str(tomo_name)] = new_row
+    _write_job_global_rows(job_dir, rows)
 
-    df = pd.DataFrame(list(rows.values()))
-    starfile.write({JOB_GLOBAL_BLOCK_NAME: df}, job_star, overwrite=True)
+
+def _remove_from_job_global_star(job_dir: Path, tomo_name: str) -> None:
+    rows = _load_job_global_rows(job_dir)
+    rows.pop(str(tomo_name), None)
+    _write_job_global_rows(job_dir, rows)
+
+
+def _write_passthrough_locked(project_dir: Path, job_dir: Path, in_tiltseries: str) -> int:
+    names = list_tilt_series(project_dir, in_tiltseries)
+    for name in names:
+        df, row = _load_original_series(project_dir, in_tiltseries, name)
+        _write_series_output(project_dir, job_dir, name, row, df)
+    return len(names)
 
 
 def write_passthrough(project_dir: Path, job_dir: Path, in_tiltseries: str) -> int:
@@ -210,11 +279,8 @@ def write_passthrough(project_dir: Path, job_dir: Path, in_tiltseries: str) -> i
     Called once at job start (custom_jobs.run_exclude_tilt_images), and
     again (via clear_exclusions first) on Overwrite. Returns the number of
     tilt series written."""
-    names = list_tilt_series(project_dir, in_tiltseries)
-    for name in names:
-        df, row = _load_original_series(project_dir, in_tiltseries, name)
-        _write_series_output(project_dir, job_dir, name, row, df)
-    return len(names)
+    with _job_lock(job_dir):
+        return _write_passthrough_locked(project_dir, job_dir, in_tiltseries)
 
 
 def list_images(project_dir: Path, job_dir: Path, in_tiltseries: str, tomo_name: str) -> list[dict]:
@@ -282,7 +348,8 @@ def save_tilt_series_exclusions(
     filtered = df[mask]
     if TILT_ANGLE_COL in filtered.columns:
         filtered = filtered.sort_values(TILT_ANGLE_COL, kind="stable")
-    series_path = _write_series_output(project_dir, job_dir, tomo_name, global_row, filtered)
+    with _job_lock(job_dir):
+        series_path = _write_series_output(project_dir, job_dir, tomo_name, global_row, filtered)
     return {
         "series_path": str(series_path),
         "n_total": len(df),
@@ -291,14 +358,7 @@ def save_tilt_series_exclusions(
     }
 
 
-def clear_exclusions(job_dir: Path) -> int:
-    """Delete everything this job has written -- every per-series STAR plus
-    the job-level selected_tilt_series.star. Called at the start of an
-    Overwrite (see custom_jobs.run_exclude_tilt_images), mirroring manual_
-    pick.clear_spa_picks/clear_tomo_picks: real RELION's own "Overwrite"
-    re-runs into the SAME directory, so a fresh session needs a clean slate.
-    A fresh (never-run) job's directory has nothing to clear, so this is a
-    safe no-op there too. Returns how many files were removed."""
+def _clear_exclusions_locked(job_dir: Path) -> int:
     job_dir = Path(job_dir)
     removed = 0
     global_star = job_dir / JOB_GLOBAL_STAR_NAME
@@ -315,3 +375,29 @@ def clear_exclusions(job_dir: Path) -> int:
         except OSError:
             pass
     return removed
+
+
+def clear_exclusions(job_dir: Path) -> int:
+    """Delete everything this job has written -- every per-series STAR plus
+    the job-level selected_tilt_series.star. Called at the start of an
+    Overwrite (see custom_jobs.run_exclude_tilt_images), mirroring manual_
+    pick.clear_spa_picks/clear_tomo_picks: real RELION's own "Overwrite"
+    re-runs into the SAME directory, so a fresh session needs a clean slate.
+    A fresh (never-run) job's directory has nothing to clear, so this is a
+    safe no-op there too. Returns how many files were removed."""
+    with _job_lock(job_dir):
+        return _clear_exclusions_locked(job_dir)
+
+
+def reset_and_write_passthrough(project_dir: Path, job_dir: Path, in_tiltseries: str) -> tuple[int, int]:
+    """clear_exclusions() + write_passthrough() as ONE atomic step under a
+    single lock acquisition -- what job start (custom_jobs.
+    run_exclude_tilt_images) actually needs. Calling the two public
+    functions back-to-back would release the lock in between them, leaving
+    a window where a concurrent save request could write into (or read out
+    of) a job directory that has been cleared but not yet reseeded. Returns
+    (n_removed, n_series_written)."""
+    with _job_lock(job_dir):
+        removed = _clear_exclusions_locked(job_dir)
+        n_series = _write_passthrough_locked(project_dir, job_dir, in_tiltseries)
+    return removed, n_series

--- a/backend/exclude_tilts.py
+++ b/backend/exclude_tilts.py
@@ -1,0 +1,317 @@
+"""
+exclude_tilts.py — writes RELION-compatible tilt-series STAR output for the
+browser-based tilt-image reviewer (TomoExcludeTiltImages), which replaces
+relion_tomo_exclude_tilt_images' own napari GUI (a desktop window -- see
+tomography_python_programs/exclude_tilt_images/_cli.py: it unconditionally
+does `napari.Viewer(); ...; napari.run()`, with no headless/non-interactive
+flag at all) with a plain checkbox list rendered in the in-browser viewer.
+
+Data-level shape confirmed by reading the real Python package directly (not
+guessed): tomography_python_programs._metadata_models.relion.tilt_series_set.
+RlnTiltSeriesSet (from_star_file / write_star_file) and .exclude_tilt_images.
+relion_tilt_image_excluder.RelionTiltImageExcluderWidget.save_output --
+"excluding" an image is nothing more than a boolean-mask filter dropping rows
+from each tilt series' own per-image DataFrame (sorted by
+rlnTomoNominalStageTiltAngle), then writing one job-level "global" STAR table
+(one row per tilt series, pointing at that series' own STAR file) plus one
+per-series STAR file each. No napari/GUI dependency is needed to REPRODUCE
+this file format, only to let a human interactively choose which rows to
+drop -- exactly the same reasoning manual_pick.py documents for Manualpick.
+
+Row identity: rlnMicrographMovieName (unique per image within one tilt
+series -- confirmed against a real CtfFind tilt_series/*.star, e.g.
+"frames/TS_01_000_0.0.mrc"). There is no separate "excluded" flag anywhere in
+the real output format -- an excluded row is simply absent from the written
+per-series STAR -- so THIS module never invents one either. Instead, "is
+image X currently excluded" is answered by comparing the ORIGINAL per-series
+STAR (read fresh from the job's own `in_tiltseries` input every time, never
+cached) against whatever this job has itself written so far into its own
+`tilt_series/<name>.star` copy: present in the original but absent from the
+job's own copy == currently excluded. This needs no sidecar state file, and
+naturally supports re-including something excluded in an earlier save.
+
+Immediately-usable default: unlike SPA/tomo manual picking (where an unpicked
+job has literally no particles yet), a tilt-series job has an obvious,
+non-destructive "nothing chosen yet" state -- keep every tilt image. See
+write_passthrough(), called once at job start (custom_jobs.
+run_exclude_tilt_images) so this job's output is already valid for
+downstream jobs (Reconstruct Tomograms, TomoSubtomo, ...) even before the
+user opens the reviewer at all.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+import viz
+
+TILT_SERIES_DIRNAME = "tilt_series"
+JOB_GLOBAL_STAR_NAME = "selected_tilt_series.star"
+JOB_GLOBAL_BLOCK_NAME = "global"
+
+# Columns on the job's own "global" table (one row per tilt series) -- the
+# same shape TomoImport/TomoMotioncorr/TomoCtffind all produce/consume, per
+# data/job_definitions_raw.json's TomoExcludeTiltImages.in_tiltseries help
+# text ("Input global tilt series star file.").
+GLOBAL_TOMO_NAME_COL = "rlnTomoName"
+GLOBAL_STARFILE_COL = "rlnTomoTiltSeriesStarFile"
+
+# Per-image columns on one tilt series' own STAR file -- confirmed against a
+# real CtfFind tilt_series/TS_*.star (RELION 5.0.1 tomography tutorial).
+MOVIE_COL = "rlnMicrographMovieName"
+MIC_NAME_COL = "rlnMicrographName"
+TILT_ANGLE_COL = "rlnTomoNominalStageTiltAngle"
+PRE_EXPOSURE_COL = "rlnMicrographPreExposure"
+CTF_MAXRES_COL = "rlnCtfMaxResolution"
+MOTION_COL = "rlnAccumMotionTotal"
+
+
+class ExcludeTiltsError(Exception):
+    """Raised for a bad request (unreadable path, unknown tomogram, etc.);
+    the API turns this into a 400."""
+
+
+def _sanitize(name: str) -> str:
+    """A tilt series name, made safe as a flat filename fragment -- same
+    rule as manual_pick._sanitize_relpath, kept collision-free even though
+    real RELION-5 tomogram names are already filesystem-safe in practice."""
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", str(name).strip("/"))
+
+
+def _read_star_blocks(path: Path) -> dict:
+    import starfile
+
+    return starfile.read(path, always_dict=True)
+
+
+def _read_global_table(project_dir: Path, in_tiltseries: str):
+    """The job's input `in_tiltseries` -- a RELION-5 tomography tilt-series
+    SET star, one row per tilt series, each pointing at that series' own
+    per-image STAR file (rlnTomoTiltSeriesStarFile)."""
+    p = viz._safe(project_dir, in_tiltseries)
+    if not p.is_file():
+        raise ExcludeTiltsError(f"tilt series STAR not found: {in_tiltseries}")
+    blocks = _read_star_blocks(p)
+    for df in blocks.values():
+        if hasattr(df, "columns") and GLOBAL_TOMO_NAME_COL in df.columns and GLOBAL_STARFILE_COL in df.columns:
+            return df
+    raise ExcludeTiltsError(
+        f"{p.name}: no {GLOBAL_TOMO_NAME_COL}/{GLOBAL_STARFILE_COL} columns found "
+        f"(expected a RELION-5 tomography tilt-series-set STAR, e.g. CtfFind's own "
+        f"tilt_series_ctf.star)."
+    )
+
+
+def _global_row(df, tomo_name: str):
+    matches = df[df[GLOBAL_TOMO_NAME_COL].astype(str) == str(tomo_name)]
+    if matches.empty:
+        raise ExcludeTiltsError(f"tomogram '{tomo_name}' not found in the input tilt series STAR")
+    return matches.iloc[0]
+
+
+def list_tilt_series(project_dir: Path, in_tiltseries: str) -> list[str]:
+    """Every tilt series this job's `in_tiltseries` names, in file order."""
+    df = _read_global_table(project_dir, in_tiltseries)
+    return [str(v) for v in df[GLOBAL_TOMO_NAME_COL].tolist()]
+
+
+def _load_original_series(project_dir: Path, in_tiltseries: str, tomo_name: str):
+    """This tomogram's own per-image STAR, read fresh from the job's input
+    (NEVER from this job's own already-written copy -- that copy only ever
+    holds the KEPT rows, so re-deriving from it would make an excluded image
+    permanently unrecoverable). Returns (full DataFrame, global-table row)."""
+    gdf = _read_global_table(project_dir, in_tiltseries)
+    row = _global_row(gdf, tomo_name)
+    star_rel = str(row[GLOBAL_STARFILE_COL])
+    p = viz._safe(project_dir, star_rel)
+    if not p.is_file():
+        raise ExcludeTiltsError(f"per-tilt-series STAR not found: {star_rel}")
+    blocks = _read_star_blocks(p)
+    df = blocks.get(tomo_name)
+    if df is None:
+        df = next(iter(blocks.values()), None)
+    if df is None or MOVIE_COL not in df.columns:
+        raise ExcludeTiltsError(f"{p.name}: no {MOVIE_COL} column found")
+    return df, row
+
+
+def _job_series_path(job_dir: Path, tomo_name: str) -> Path:
+    return Path(job_dir) / TILT_SERIES_DIRNAME / f"{_sanitize(tomo_name)}.star"
+
+
+def _read_job_series(job_dir: Path, tomo_name: str):
+    """This job's own already-saved copy of one tilt series (the KEPT rows
+    only), or None if nothing has been saved for it yet."""
+    p = _job_series_path(Path(job_dir), tomo_name)
+    if not p.is_file():
+        return None
+    blocks = _read_star_blocks(p)
+    df = blocks.get(tomo_name)
+    if df is None:
+        df = next(iter(blocks.values()), None)
+    return df
+
+
+def _write_series_output(project_dir: Path, job_dir: Path, tomo_name: str, global_row, df) -> Path:
+    """Write one tilt series' own STAR (the block-name/filename convention a
+    real relion_tomo_exclude_tilt_images run produces: data_<TomoName>, at
+    <job_dir>/tilt_series/<TomoName>.star) and upsert this tomogram's row in
+    the job-level selected_tilt_series.star (data_global), pointing at the
+    file just written rather than the original input's copy."""
+    import starfile
+
+    job_dir = Path(job_dir)
+    series_path = _job_series_path(job_dir, tomo_name)
+    series_path.parent.mkdir(parents=True, exist_ok=True)
+    starfile.write({tomo_name: df.reset_index(drop=True)}, series_path, overwrite=True)
+    _upsert_job_global_star(project_dir, job_dir, tomo_name, global_row, series_path)
+    return series_path
+
+
+def _upsert_job_global_star(project_dir: Path, job_dir: Path, tomo_name: str, global_row, series_path: Path) -> None:
+    import starfile
+
+    job_dir = Path(job_dir)
+    job_star = job_dir / JOB_GLOBAL_STAR_NAME
+    rows: dict[str, dict] = {}
+    if job_star.is_file():
+        try:
+            blocks = _read_star_blocks(job_star)
+            # NOT `blocks.get(...) or next(...)` -- a DataFrame's truthiness
+            # is ambiguous (raises ValueError), which the except below would
+            # silently swallow, resetting `rows` to {} and losing every
+            # OTHER tilt series' row already written (confirmed for real:
+            # write_passthrough's loop wrote only the LAST series processed
+            # before this fix, discarding the rest on each subsequent call).
+            existing = blocks.get(JOB_GLOBAL_BLOCK_NAME)
+            if existing is None:
+                existing = next(iter(blocks.values()), None)
+            if existing is not None and GLOBAL_TOMO_NAME_COL in existing.columns:
+                for _, r in existing.iterrows():
+                    rows[str(r[GLOBAL_TOMO_NAME_COL])] = r.to_dict()
+        except Exception:  # noqa: BLE001
+            rows = {}
+
+    new_row = global_row.to_dict()
+    new_row[GLOBAL_TOMO_NAME_COL] = str(tomo_name)
+    new_row[GLOBAL_STARFILE_COL] = str(series_path.relative_to(project_dir))
+    rows[str(tomo_name)] = new_row
+
+    df = pd.DataFrame(list(rows.values()))
+    starfile.write({JOB_GLOBAL_BLOCK_NAME: df}, job_star, overwrite=True)
+
+
+def write_passthrough(project_dir: Path, job_dir: Path, in_tiltseries: str) -> int:
+    """Write every tilt series this job's input names, with NOTHING
+    excluded -- the job's immediately-usable default (see module docstring).
+    Called once at job start (custom_jobs.run_exclude_tilt_images), and
+    again (via clear_exclusions first) on Overwrite. Returns the number of
+    tilt series written."""
+    names = list_tilt_series(project_dir, in_tiltseries)
+    for name in names:
+        df, row = _load_original_series(project_dir, in_tiltseries, name)
+        _write_series_output(project_dir, job_dir, name, row, df)
+    return len(names)
+
+
+def list_images(project_dir: Path, job_dir: Path, in_tiltseries: str, tomo_name: str) -> list[dict]:
+    """Every image in this tilt series, with its current excluded state --
+    see module docstring for how "excluded" is derived (no stored flag,
+    just "in the original, not in this job's own kept copy")."""
+    df, _ = _load_original_series(project_dir, in_tiltseries, tomo_name)
+    df = df.reset_index(drop=True)
+    kept = _read_job_series(job_dir, tomo_name)
+    kept_names: Optional[set] = None
+    if kept is not None and MOVIE_COL in kept.columns:
+        kept_names = set(kept[MOVIE_COL].astype(str))
+
+    def _f(row, col):
+        if col not in df.columns:
+            return None
+        v = row[col]
+        return None if pd.isna(v) else float(v)
+
+    images = []
+    for i, row in df.iterrows():
+        movie = str(row[MOVIE_COL])
+        images.append({
+            "index": int(i),
+            "movie_name": movie,
+            "mic_name": str(row[MIC_NAME_COL]) if MIC_NAME_COL in df.columns else "",
+            "tilt_angle": _f(row, TILT_ANGLE_COL),
+            "pre_exposure": _f(row, PRE_EXPOSURE_COL),
+            "ctf_max_resolution": _f(row, CTF_MAXRES_COL),
+            "accum_motion_total": _f(row, MOTION_COL),
+            "excluded": (movie not in kept_names) if kept_names is not None else False,
+        })
+    return images
+
+
+def series_summary(project_dir: Path, job_dir: Path, in_tiltseries: str) -> list[dict]:
+    """One row per tilt series -- name, total image count, and how many are
+    currently excluded -- for the reviewer's tilt-series list."""
+    out = []
+    for name in list_tilt_series(project_dir, in_tiltseries):
+        df, _ = _load_original_series(project_dir, in_tiltseries, name)
+        n_total = len(df)
+        kept = _read_job_series(job_dir, name)
+        n_kept = len(kept) if kept is not None else n_total
+        out.append({"name": name, "n_images": n_total, "n_excluded": n_total - n_kept})
+    return out
+
+
+def save_tilt_series_exclusions(
+    project_dir: Path, job_dir: Path, in_tiltseries: str, tomo_name: str,
+    excluded_movie_names: list[str],
+) -> dict:
+    """Drop the named images (by rlnMicrographMovieName) from this tilt
+    series and rewrite its own STAR + the job-level selected_tilt_series.star
+    row for it. Always re-derives from the ORIGINAL input (see
+    _load_original_series), so re-including a previously-excluded image is
+    just calling this again without it in `excluded_movie_names` -- there is
+    no accumulation across saves.
+
+    Rows are sorted by rlnTomoNominalStageTiltAngle before writing, matching
+    RelionTiltImageExcluderWidget.save_output's own convention."""
+    df, global_row = _load_original_series(project_dir, in_tiltseries, tomo_name)
+    excluded = {str(v) for v in (excluded_movie_names or [])}
+    mask = ~df[MOVIE_COL].astype(str).isin(excluded)
+    filtered = df[mask]
+    if TILT_ANGLE_COL in filtered.columns:
+        filtered = filtered.sort_values(TILT_ANGLE_COL, kind="stable")
+    series_path = _write_series_output(project_dir, job_dir, tomo_name, global_row, filtered)
+    return {
+        "series_path": str(series_path),
+        "n_total": len(df),
+        "n_kept": len(filtered),
+        "n_excluded": len(df) - len(filtered),
+    }
+
+
+def clear_exclusions(job_dir: Path) -> int:
+    """Delete everything this job has written -- every per-series STAR plus
+    the job-level selected_tilt_series.star. Called at the start of an
+    Overwrite (see custom_jobs.run_exclude_tilt_images), mirroring manual_
+    pick.clear_spa_picks/clear_tomo_picks: real RELION's own "Overwrite"
+    re-runs into the SAME directory, so a fresh session needs a clean slate.
+    A fresh (never-run) job's directory has nothing to clear, so this is a
+    safe no-op there too. Returns how many files were removed."""
+    job_dir = Path(job_dir)
+    removed = 0
+    global_star = job_dir / JOB_GLOBAL_STAR_NAME
+    if global_star.is_file():
+        global_star.unlink()
+        removed += 1
+    series_dir = job_dir / TILT_SERIES_DIRNAME
+    if series_dir.is_dir():
+        for f in series_dir.glob("*.star"):
+            f.unlink()
+            removed += 1
+        try:
+            series_dir.rmdir()
+        except OSError:
+            pass
+    return removed

--- a/backend/job_catalog.py
+++ b/backend/job_catalog.py
@@ -77,8 +77,6 @@ JOB_CATALOG = {
                                    "Reconstruction of tomograms for particle picking"),
     "TomoDenoiseTomograms":      ("relion.denoisetomo", "Denoise Tomograms", "Tilt Series / Tomogram Reconstruction",
                                    "Denoise tomograms"),
-    "TomoExcludeTiltImages":     ("relion.excludetilts", "Exclude Tilt Images", "Tilt Series / Tomogram Reconstruction",
-                                   "Exclusion of bad tilt-images from tilt-series"),
     "Extract":                   ("relion.extract", "Particle Extraction", "Extraction",
                                    "Window particles, normalize, downsize etc from micrographs"),
     "TomoSubtomo":               ("relion.pseudosubtomo", "Extract Pseudo-subtomograms", "Extraction",
@@ -131,7 +129,7 @@ assert set(JOB_CATALOG) == {
     "Import", "TomoImport", "Motioncorr", "TomoMotioncorr", "Ctffind", "TomoCtffind",
     "Ctfrefine", "TomoCtfRefine",
     "Autopick", "TomoPickTomograms", "TomoAlignTiltSeries",
-    "TomoReconstructTomograms", "TomoDenoiseTomograms", "TomoExcludeTiltImages",
+    "TomoReconstructTomograms", "TomoDenoiseTomograms",
     "Extract", "TomoSubtomo", "Select", "Class2D", "Inimodel", "Class3D",
     "Autorefine", "MultiBody", "TomoAlign", "TomoReconPart", "Motionrefine",
     "Maskcreate", "Joinstar", "Subtract", "Postprocess", "Localres", "DynaMight",
@@ -147,7 +145,14 @@ assert set(JOB_CATALOG) == {
     "label (relion.manualpick) so it still shows up correctly in RELION's "
     "own pipeline/GUI, but its actual picking happens through the in-browser "
     "tomogram/micrograph viewer (viz.py) rather than a subprocess -- see "
-    "custom_jobs.py."
+    "custom_jobs.py. TomoExcludeTiltImages is likewise deliberately NOT here "
+    "-- relion_tomo_exclude_tilt_images (tomography_python_programs/"
+    "exclude_tilt_images/_cli.py) unconditionally opens a napari desktop "
+    "window (napari.Viewer()/napari.run(), no headless flag at all), the "
+    "exact same problem as relion_manualpick. It's registered in CUSTOM_JOBS "
+    "below too, under its own real RELION type label (relion.excludetilts), "
+    "with the actual review/exclusion happening through an in-browser tilt-"
+    "image list (exclude_tilts.py) instead of a subprocess."
 )
 
 # Motioncorr/Ctffind are ONE real RelionJob class each, with is_tomo a plain
@@ -183,24 +188,25 @@ AMBIGUOUS_TOMO_LABELS = {JOB_CATALOG[base][0] for base in set(TOMO_VARIANT_OF.va
 # in the Jobs list, but see job_runner.py for how they execute (direct
 # in-process Python calls into backend/converters/, not a subprocess).
 #
-# Manualpick/TomoManualPick are a different kind of "custom" job from the
-# import bridges below: their label_new is a REAL RELION type label
-# (relion.manualpick / relion.picktomo, the same one TomoPickTomograms uses
-# for automated tomogram picking), not a custom.* one -- see
-# job_runner.py's _register_in_relion_pipeline, which now checks CUSTOM_JOBS
-# for a label_new the same way it checks JOB_CATALOG, and pipeline_bridge's
-# module docstring for why registering under the real label matters: it's
-# what lets `relion_pipeliner --addJobFromStar` (called on Run, same as any
-# other job when two-way sync is on) recognize the job type, validate it,
-# and compute its real output nodes -- so a picking job registered here
-# shows up correctly in RELION's own pipeline/GUI and its output is a valid
-# input to any real downstream RELION job (Extract, TomoSubtomo, ...),
-# exactly as if a real relion_manualpick/relion_python_tomo_pick had
-# produced it. The import bridges below use custom.* labels precisely
-# because they AREN'T standing in for a real RELION job type -- registering
-# those under a label relion_pipeliner has never heard of would just fail
-# (harmlessly; _register_in_relion_pipeline's caller already falls back to
-# this app's own numbering on any registration error).
+# Manualpick/TomoManualPick/TomoExcludeTiltImages are a different kind of
+# "custom" job from the import bridges below: their label_new is a REAL
+# RELION type label (relion.manualpick / relion.picktomo / relion.
+# excludetilts, the last also used by real relion_tomo_exclude_tilt_images),
+# not a custom.* one -- see job_runner.py's _register_in_relion_pipeline,
+# which now checks CUSTOM_JOBS for a label_new the same way it checks
+# JOB_CATALOG, and pipeline_bridge's module docstring for why registering
+# under the real label matters: it's what lets `relion_pipeliner
+# --addJobFromStar` (called on Run, same as any other job when two-way sync
+# is on) recognize the job type, validate it, and compute its real output
+# nodes -- so a job registered here shows up correctly in RELION's own
+# pipeline/GUI and its output is a valid input to any real downstream RELION
+# job (Extract, TomoSubtomo, Reconstruct Tomograms, ...), exactly as if a
+# real relion_manualpick/relion_python_tomo_pick/relion_tomo_exclude_tilt_
+# images had produced it. The import bridges below use custom.* labels
+# precisely because they AREN'T standing in for a real RELION job type --
+# registering those under a label relion_pipeliner has never heard of would
+# just fail (harmlessly; _register_in_relion_pipeline's caller already
+# falls back to this app's own numbering on any registration error).
 CUSTOM_JOBS = {
     "Manualpick": {
         "label_new": "relion.manualpick",
@@ -213,6 +219,12 @@ CUSTOM_JOBS = {
         "display_name": "Manual Picking (Tomo)",
         "category": "Particle Picking",
         "description": "Manually pick particles in tomograms",
+    },
+    "TomoExcludeTiltImages": {
+        "label_new": "relion.excludetilts",
+        "display_name": "Exclude Tilt Images",
+        "category": "Tilt Series / Tomogram Reconstruction",
+        "description": "Exclusion of bad tilt-images from tilt-series",
     },
     "ImodImport": {
         "label_new": "custom.imod_import",
@@ -1579,17 +1591,12 @@ DRAFT_OVERRIDES: dict[str, JobDraftOverride] = {
             "dose_is_per_movie_frame", "do_coords",
         }),
     ),
-    # getCommandsTomoExcludeTiltImagesJob (src/pipeline_jobs.cpp ~7017-7040):
-    #   `which relion_python_tomo_exclude_tilt_images`
-    #     --tilt-series-star-file <in_tiltseries> --cache-size <cache_size>
-    #     --output-directory <out>
-    "TomoExcludeTiltImages": JobDraftOverride(
-        output_flag="--output-directory",
-        flags={
-            "in_tiltseries": FlagOverride("--tilt-series-star-file"),
-            "cache_size": FlagOverride("--cache-size"),
-        },
-    ),
+    # TomoExcludeTiltImages has no draft-command entry here anymore -- it
+    # moved to CUSTOM_JOBS (see that table's docstring above): its real
+    # program, relion_tomo_exclude_tilt_images, opens a napari desktop
+    # window unconditionally, so it can no longer be drafted/run as a
+    # subprocess at all. See exclude_tilts.py / custom_jobs.py.
+    #
     # Verified per-job against getCommands*Job() in src/pipeline_jobs.cpp
     # (RELION cloned 2026-08-14): both take --output-directory, not the
     # default --o. (NB: TomoAlignTiltSeries and TomoReconstructTomograms

--- a/backend/main.py
+++ b/backend/main.py
@@ -160,6 +160,7 @@ from starlette.background import BackgroundTask
 import analyze
 import auth
 import ctf_qc
+import exclude_tilts
 import job_registry
 import progress
 import pipeline_bridge
@@ -519,11 +520,12 @@ async def abort_run(run_id: str):
 
 @app.post("/api/runs/{run_id}/resume")
 async def resume_run(run_id: str):
-    """The picking jobs' "Continue" toolbar action -- see
-    JobRunManager.resume_run's own docstring. Restricted to Manualpick/
-    TomoManualPick here (not exposed generically): resuming a finished
-    subprocess/compute job back to "running" has no real meaning -- there
-    is no process left to have stopped."""
+    """The picker-style custom jobs' "Continue" toolbar action -- see
+    JobRunManager.resume_run's own docstring. Restricted to jobs whose
+    CUSTOM_JOB_DEFINITIONS entry sets is_picker (Manualpick/TomoManualPick/
+    TomoExcludeTiltImages) here (not exposed generically): resuming a
+    finished subprocess/compute job back to "running" has no real meaning --
+    there is no process left to have stopped."""
     _reject_relion_run(run_id, "resumed")
     run = run_manager.get(run_id)
     internal_name = run.internal_name if run else None
@@ -534,7 +536,7 @@ async def resume_run(run_id: str):
     if internal_name is None or not CUSTOM_JOB_DEFINITIONS.get(internal_name, {}).get("is_picker"):
         raise HTTPException(
             status_code=400,
-            detail="Only a manual-picking job (Manualpick/TomoManualPick) can be resumed.",
+            detail="Only a picker-style job (Manualpick/TomoManualPick/TomoExcludeTiltImages) can be resumed.",
         )
     try:
         updated = await run_manager.resume_run(run_id)
@@ -1365,10 +1367,16 @@ def viz_slice(
     # The orthogonal viewer's left panel needs [y, z] rather than [z, y]; see
     # viz.render_slice_png().
     transpose: bool = Query(False),
+    # Overridable so a caller rendering many small thumbnails at once (the
+    # Exclude Tilt Images reviewer's per-image list, dozens of images per
+    # tilt series) can ask for a genuinely small PNG instead of downloading
+    # render_slice_png's full 1200px default and letting CSS scale it down
+    # client-side.
+    max_dim: int = Query(1200),
 ):
     try:
         png = viz.render_slice_png(
-            run_manager.project_dir, mrc_path, axis, index, lo, hi, transpose=transpose
+            run_manager.project_dir, mrc_path, axis, index, lo, hi, max_dim=max_dim, transpose=transpose
         )
     except viz.VizError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
@@ -1457,6 +1465,65 @@ def manual_pick_tomo_save(run_id: str, req: TomoPickSaveRequest):
         return manual_pick.save_tomo_picks(
             run_manager.project_dir, job_dir, req.tomo_name, req.picks, req.tomograms_star_path)
     except (manual_pick.ManualPickError, viz.VizError, OSError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+# --------------------------------------------------------------------------
+# Exclude Tilt Images (TomoExcludeTiltImages) -- the in-browser tilt-image
+# reviewer, replacing relion_tomo_exclude_tilt_images' own napari GUI (a
+# desktop window with no headless flag at all -- see exclude_tilts.py's
+# module docstring) the same way manual_pick.py replaces relion_manualpick's
+# FLTK canvas above. Saves/loads into a specific job's own output directory
+# -- see exclude_tilts.py for the STAR formats this writes.
+# --------------------------------------------------------------------------
+
+
+def _exclude_tilts_job(run_id: str) -> tuple[Path, str]:
+    """This run's own output dir + its recorded `in_tiltseries` input -- 404
+    if the run doesn't exist, 400 if it has no input recorded (shouldn't
+    happen in practice: the runner requires it -- see custom_jobs.
+    run_exclude_tilt_images -- but a hand-crafted/imported run could lack
+    it)."""
+    run = run_manager.get(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Unknown run_id")
+    in_tiltseries = (run.field_values or {}).get("in_tiltseries", "")
+    if not in_tiltseries:
+        raise HTTPException(status_code=400, detail="This job has no input tilt series STAR recorded.")
+    return Path(run.cwd), in_tiltseries
+
+
+@app.get("/api/exclude-tilts/{run_id}/series")
+def exclude_tilts_series(run_id: str):
+    job_dir, in_tiltseries = _exclude_tilts_job(run_id)
+    try:
+        return {"series": exclude_tilts.series_summary(run_manager.project_dir, job_dir, in_tiltseries)}
+    except exclude_tilts.ExcludeTiltsError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@app.get("/api/exclude-tilts/{run_id}/images")
+def exclude_tilts_images(run_id: str, tomo_name: str = Query(...)):
+    job_dir, in_tiltseries = _exclude_tilts_job(run_id)
+    try:
+        return {"images": exclude_tilts.list_images(run_manager.project_dir, job_dir, in_tiltseries, tomo_name)}
+    except exclude_tilts.ExcludeTiltsError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+class ExcludeTiltsSaveRequest(BaseModel):
+    tomo_name: str
+    excluded_movie_names: list[str]
+
+
+@app.post("/api/exclude-tilts/{run_id}/save")
+def exclude_tilts_save(run_id: str, req: ExcludeTiltsSaveRequest):
+    job_dir, in_tiltseries = _exclude_tilts_job(run_id)
+    try:
+        return exclude_tilts.save_tilt_series_exclusions(
+            run_manager.project_dir, job_dir, in_tiltseries, req.tomo_name, req.excluded_movie_names,
+        )
+    except (exclude_tilts.ExcludeTiltsError, OSError) as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
 

--- a/backend/tests/fake_relion_pipeliner.py
+++ b/backend/tests/fake_relion_pipeliner.py
@@ -40,6 +40,7 @@ DIRNAME_BY_LABEL = {
     "relion.select": "Select",
     "relion.manualpick": "ManualPick",
     "relion.picktomo": "Picks",
+    "relion.excludetilts": "ExcludeTiltImages",
 }
 
 EXIT_FILES = {

--- a/backend/tests/test_custom_jobs.py
+++ b/backend/tests/test_custom_jobs.py
@@ -411,6 +411,167 @@ def test_overwrite_clears_prior_picks_and_resumes_running(synced_project):
     assert manual_pick.load_spa_picks(project, Path(overwritten.cwd), "a.mrc") == []
 
 
+def _seed_tilt_series(project):
+    """Same minimal CtfFind-shaped input test_exclude_tilts.py's own
+    fixture uses -- one tilt series, two images."""
+    ctf_dir = project / "CtfFind" / "job002" / "tilt_series"
+    ctf_dir.mkdir(parents=True)
+    series_df = pd.DataFrame({
+        "rlnMicrographMovieName": ["a.mrc", "b.mrc"],
+        "rlnTomoNominalStageTiltAngle": [0.0, 3.0],
+        "rlnMicrographName": ["MotionCorr/job001/a.mrc", "MotionCorr/job001/b.mrc"],
+    })
+    starfile.write({"TS_01": series_df}, ctf_dir / "TS_01.star", overwrite=True)
+    global_df = pd.DataFrame({
+        "rlnTomoName": ["TS_01"],
+        "rlnTomoTiltSeriesStarFile": ["CtfFind/job002/tilt_series/TS_01.star"],
+        "rlnVoltage": [300.0],
+    })
+    starfile.write({"global": global_df}, project / "CtfFind" / "job002" / "tilt_series_ctf.star", overwrite=True)
+    return "CtfFind/job002/tilt_series_ctf.star"
+
+
+# --------------------------------------------------------------------------
+# TomoExcludeTiltImages -- same is_picker/stays_running lifecycle as
+# Manualpick above; see exclude_tilts.py for the STAR output this job's
+# reviewer actually writes. run_exclude_tilt_images itself writes a full
+# pass-through default (see its own docstring) rather than leaving the job's
+# output missing until the user opens the reviewer -- unlike Manualpick,
+# whose unpicked job genuinely has no particles yet.
+# --------------------------------------------------------------------------
+
+
+def test_run_exclude_tilt_images_reports_series_count_and_passthrough(tmp_path):
+    project_manager.init_new_project(tmp_path)
+    in_tiltseries = _seed_tilt_series(tmp_path)
+    job_dir = tmp_path / "job001"
+    summary = asyncio.run(
+        custom_jobs.run_exclude_tilt_images(tmp_path, {"in_tiltseries": in_tiltseries}, job_dir))
+    assert "Found 1 tilt series" in summary
+    assert "kept by default" in summary
+    assert (job_dir / "selected_tilt_series.star").is_file()
+    assert (job_dir / "tilt_series" / "TS_01.star").is_file()
+
+
+def test_run_exclude_tilt_images_requires_in_tiltseries(tmp_path):
+    with pytest.raises(ValueError, match="required"):
+        asyncio.run(custom_jobs.run_exclude_tilt_images(tmp_path, {}, tmp_path / "job001"))
+
+
+def test_excludetiltimages_job_registers_in_relions_pipeline_and_stays_running(synced_project):
+    """End-to-end, mirroring test_manualpick_job_registers_in_relions_
+    pipeline_and_gets_an_exit_marker / test_stays_running_job_reaches_
+    running_not_completed above: registers under its real relion.
+    excludetilts label, and a successful run_exclude_tilt_images leaves the
+    run "running" (stays_running=is_picker), not auto-completed."""
+    project = synced_project
+    in_tiltseries = _seed_tilt_series(project)
+    manager = JobRunManager(project)
+    values = {"in_tiltseries": in_tiltseries}
+
+    async def go():
+        async def factory(job_dir):
+            return await custom_jobs.run_exclude_tilt_images(project, values, job_dir)
+        run = await manager.start_custom_job(
+            "TomoExcludeTiltImages", "Exclude Tilt Images", factory, field_values=values, stays_running=True)
+        for _ in range(200):
+            await asyncio.sleep(0.02)
+            if run.status != "pending":
+                break
+        return run
+
+    run = asyncio.run(go())
+    assert run.status == "running"
+    assert run.ended_at is None
+    job_dir = Path(run.cwd)
+    assert job_dir.parent.name == "ExcludeTiltImages"
+    assert (job_dir / "selected_tilt_series.star").is_file()
+    pipeline = project_manager.read_relion_pipeline(project)
+    proc = next(p for p in pipeline["processes"] if p["name"] == f"ExcludeTiltImages/{job_dir.name}")
+    assert proc["status_label"] == "Running"
+
+
+def test_excludetiltimages_done_then_continue_preserves_saved_exclusions(synced_project):
+    """Done finishes the session (full completion handshake, like
+    Manualpick's); Continue (resume_run) returns to "running" WITHOUT
+    touching any saved exclusion -- mirrors test_done_button_finishes_a_
+    stays_running_job / test_resume_run_returns_to_running_without_
+    touching_picks above."""
+    project = synced_project
+    in_tiltseries = _seed_tilt_series(project)
+    manager = JobRunManager(project)
+    values = {"in_tiltseries": in_tiltseries}
+
+    async def go():
+        async def factory(job_dir):
+            return await custom_jobs.run_exclude_tilt_images(project, values, job_dir)
+        run = await manager.start_custom_job(
+            "TomoExcludeTiltImages", "Exclude Tilt Images", factory, field_values=values, stays_running=True)
+        for _ in range(200):
+            await asyncio.sleep(0.02)
+            if run.status != "pending":
+                break
+        import exclude_tilts
+        exclude_tilts.save_tilt_series_exclusions(project, Path(run.cwd), in_tiltseries, "TS_01", ["a.mrc"])
+        await manager.set_status(run.run_id, "completed")
+        assert run.status == "completed"
+        assert (Path(run.cwd) / "RELION_JOB_EXIT_SUCCESS").is_file()
+        updated = await manager.resume_run(run.run_id)
+        return run, updated
+
+    run, updated = asyncio.run(go())
+    assert run.status == "running"
+    assert updated["status"] == "running"
+    import exclude_tilts
+    images = exclude_tilts.list_images(project, Path(run.cwd), in_tiltseries, "TS_01")
+    assert [i["movie_name"] for i in images if i["excluded"]] == ["a.mrc"]
+    pipeline = project_manager.read_relion_pipeline(project)
+    proc = next(p for p in pipeline["processes"] if p["name"] == f"ExcludeTiltImages/{Path(run.cwd).name}")
+    assert proc["status_label"] == "Running"
+
+
+def test_excludetiltimages_overwrite_clears_prior_exclusions(synced_project):
+    """Overwrite is the destructive counterpart to Continue -- mirrors
+    test_overwrite_clears_prior_picks_and_resumes_running above: it must
+    genuinely clear the job's prior output (run_exclude_tilt_images calls
+    exclude_tilts.clear_exclusions at the top) and re-seed a fresh
+    pass-through, not just reset run.status."""
+    project = synced_project
+    in_tiltseries = _seed_tilt_series(project)
+    manager = JobRunManager(project)
+    values = {"in_tiltseries": in_tiltseries}
+
+    async def go():
+        async def factory(job_dir):
+            return await custom_jobs.run_exclude_tilt_images(project, values, job_dir)
+        run = await manager.start_custom_job(
+            "TomoExcludeTiltImages", "Exclude Tilt Images", factory, field_values=values, stays_running=True)
+        for _ in range(200):
+            await asyncio.sleep(0.02)
+            if run.status != "pending":
+                break
+        import exclude_tilts
+        exclude_tilts.save_tilt_series_exclusions(project, Path(run.cwd), in_tiltseries, "TS_01", ["a.mrc"])
+        await manager.set_status(run.run_id, "completed")
+
+        overwritten = await manager.start_custom_job(
+            "TomoExcludeTiltImages", "Exclude Tilt Images", factory, field_values=values,
+            overwrite_run_id=run.run_id, stays_running=True,
+        )
+        for _ in range(200):
+            await asyncio.sleep(0.02)
+            if overwritten.status != "pending":
+                break
+        return run, overwritten
+
+    run, overwritten = asyncio.run(go())
+    assert overwritten.run_id == run.run_id  # same slot
+    assert overwritten.status == "running"
+    import exclude_tilts
+    images = exclude_tilts.list_images(project, Path(overwritten.cwd), in_tiltseries, "TS_01")
+    assert all(not i["excluded"] for i in images)  # back to the fresh pass-through
+
+
 def test_overwrite_works_directly_on_a_still_running_picking_session(synced_project):
     """A picker's "running" status means "picking session open," not
     "compute in progress" -- Overwrite must be usable straight from that

--- a/backend/tests/test_exclude_tilts.py
+++ b/backend/tests/test_exclude_tilts.py
@@ -1,0 +1,228 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import exclude_tilts
+
+starfile = pytest.importorskip("starfile")
+
+
+def _series_df(movie_names, angles):
+    return pd.DataFrame({
+        "rlnMicrographMovieName": movie_names,
+        "rlnTomoTiltMovieFrameCount": [8] * len(movie_names),
+        "rlnTomoNominalStageTiltAngle": angles,
+        "rlnMicrographPreExposure": [i * 3.0 for i in range(len(movie_names))],
+        "rlnMicrographName": [f"MotionCorr/job001/{n}" for n in movie_names],
+        "rlnCtfMaxResolution": [7.0] * len(movie_names),
+        "rlnAccumMotionTotal": [2.0] * len(movie_names),
+    })
+
+
+def _project(tmp_path, series=None):
+    """A project with a CtfFind-shaped global tilt-series-set star (data_
+    global: rlnTomoName/rlnTomoTiltSeriesStarFile/...) plus one per-series
+    star per entry -- the exact shape confirmed against a real RELION 5.0.1
+    tomography tutorial project's CtfFind/job002/tilt_series_ctf.star +
+    CtfFind/job002/tilt_series/TS_01.star."""
+    (tmp_path / ".relion_us").mkdir(exist_ok=True)
+    series = series or {"TS_01": (["a.mrc", "b.mrc", "c.mrc"], [0.0, 3.0, -3.0])}
+    ctf_dir = tmp_path / "CtfFind" / "job002" / "tilt_series"
+    ctf_dir.mkdir(parents=True, exist_ok=True)
+    rows = []
+    for name, (movies, angles) in series.items():
+        df = _series_df(movies, angles)
+        starfile.write({name: df}, ctf_dir / f"{name}.star", overwrite=True)
+        rows.append({
+            "rlnTomoName": name,
+            "rlnTomoTiltSeriesStarFile": f"CtfFind/job002/tilt_series/{name}.star",
+            "rlnVoltage": 300.0, "rlnSphericalAberration": 2.7,
+            "rlnAmplitudeContrast": 0.1, "rlnMicrographOriginalPixelSize": 0.675,
+            "rlnTomoHand": -1.0, "rlnOpticsGroupName": "optics1",
+            "rlnTomoTiltSeriesPixelSize": 1.35,
+        })
+    global_df = pd.DataFrame(rows)
+    starfile.write({"global": global_df}, tmp_path / "CtfFind" / "job002" / "tilt_series_ctf.star", overwrite=True)
+    return tmp_path
+
+
+IN_TILTSERIES = "CtfFind/job002/tilt_series_ctf.star"
+
+
+# --------------------------------------------------------------------------
+# list_tilt_series / list_images
+# --------------------------------------------------------------------------
+
+
+def test_list_tilt_series(tmp_path):
+    project = _project(tmp_path, series={
+        "TS_01": (["a.mrc"], [0.0]), "TS_02": (["b.mrc"], [0.0]),
+    })
+    assert exclude_tilts.list_tilt_series(project, IN_TILTSERIES) == ["TS_01", "TS_02"]
+
+
+def test_list_tilt_series_missing_star_raises(tmp_path):
+    (tmp_path / ".relion_us").mkdir()
+    with pytest.raises(exclude_tilts.ExcludeTiltsError, match="not found"):
+        exclude_tilts.list_tilt_series(tmp_path, "nope.star")
+
+
+def test_list_images_before_any_save_reports_nothing_excluded(tmp_path):
+    project = _project(tmp_path, series={
+        "TS_01": (["a.mrc", "b.mrc", "c.mrc"], [0.0, 3.0, -3.0]),
+    })
+    job_dir = project / "ExcludeTiltImages" / "job003"
+    images = exclude_tilts.list_images(project, job_dir, IN_TILTSERIES, "TS_01")
+    assert [i["movie_name"] for i in images] == ["a.mrc", "b.mrc", "c.mrc"]
+    assert all(not i["excluded"] for i in images)
+    assert images[0]["tilt_angle"] == pytest.approx(0.0)
+    assert images[1]["pre_exposure"] == pytest.approx(3.0)
+
+
+def test_list_images_unknown_tomogram_raises(tmp_path):
+    project = _project(tmp_path)
+    job_dir = project / "ExcludeTiltImages" / "job003"
+    with pytest.raises(exclude_tilts.ExcludeTiltsError, match="TS_99"):
+        exclude_tilts.list_images(project, job_dir, IN_TILTSERIES, "TS_99")
+
+
+# --------------------------------------------------------------------------
+# write_passthrough
+# --------------------------------------------------------------------------
+
+
+def test_write_passthrough_writes_every_series_with_nothing_excluded(tmp_path):
+    project = _project(tmp_path, series={
+        "TS_01": (["a.mrc", "b.mrc"], [0.0, 3.0]),
+        "TS_02": (["x.mrc"], [0.0]),
+    })
+    job_dir = project / "ExcludeTiltImages" / "job003"
+    n = exclude_tilts.write_passthrough(project, job_dir, IN_TILTSERIES)
+    assert n == 2
+
+    global_star = job_dir / "selected_tilt_series.star"
+    assert global_star.is_file()
+    gdf = starfile.read(global_star, always_dict=True)["global"]
+    # Both series present -- not just the last one written (regression
+    # guard: `blocks.get(...) or next(...)` on a DataFrame raises, which an
+    # earlier version of _upsert_job_global_star's broad except silently
+    # swallowed, resetting accumulated rows to {} on every subsequent call).
+    assert sorted(gdf["rlnTomoName"]) == ["TS_01", "TS_02"]
+    assert set(gdf["rlnTomoTiltSeriesStarFile"]) == {
+        "ExcludeTiltImages/job003/tilt_series/TS_01.star",
+        "ExcludeTiltImages/job003/tilt_series/TS_02.star",
+    }
+    # Other columns copied through from the original global row.
+    row = gdf[gdf["rlnTomoName"] == "TS_01"].iloc[0]
+    assert row["rlnVoltage"] == pytest.approx(300.0)
+
+    ts01 = starfile.read(job_dir / "tilt_series" / "TS_01.star", always_dict=True)["TS_01"]
+    assert list(ts01["rlnMicrographMovieName"]) == ["a.mrc", "b.mrc"]
+
+    summary = exclude_tilts.series_summary(project, job_dir, IN_TILTSERIES)
+    assert summary == [
+        {"name": "TS_01", "n_images": 2, "n_excluded": 0},
+        {"name": "TS_02", "n_images": 1, "n_excluded": 0},
+    ]
+
+
+# --------------------------------------------------------------------------
+# save_tilt_series_exclusions
+# --------------------------------------------------------------------------
+
+
+def test_save_exclusions_drops_named_rows_and_sorts_by_tilt_angle(tmp_path):
+    project = _project(tmp_path, series={
+        "TS_01": (["a.mrc", "b.mrc", "c.mrc"], [0.0, 9.0, -3.0]),
+    })
+    job_dir = project / "ExcludeTiltImages" / "job003"
+    result = exclude_tilts.save_tilt_series_exclusions(project, job_dir, IN_TILTSERIES, "TS_01", ["b.mrc"])
+    assert result["n_total"] == 3
+    assert result["n_kept"] == 2
+    assert result["n_excluded"] == 1
+
+    df = starfile.read(Path(result["series_path"]), always_dict=True)["TS_01"]
+    # b.mrc (9.0 deg) dropped; remaining rows sorted by tilt angle ascending
+    # (RelionTiltImageExcluderWidget.save_output's own convention).
+    assert list(df["rlnMicrographMovieName"]) == ["c.mrc", "a.mrc"]
+    assert list(df["rlnTomoNominalStageTiltAngle"]) == [-3.0, 0.0]
+
+
+def test_save_exclusions_then_list_images_reflects_state(tmp_path):
+    project = _project(tmp_path, series={
+        "TS_01": (["a.mrc", "b.mrc", "c.mrc"], [0.0, 3.0, -3.0]),
+    })
+    job_dir = project / "ExcludeTiltImages" / "job003"
+    exclude_tilts.save_tilt_series_exclusions(project, job_dir, IN_TILTSERIES, "TS_01", ["b.mrc"])
+    images = exclude_tilts.list_images(project, job_dir, IN_TILTSERIES, "TS_01")
+    excluded = {i["movie_name"] for i in images if i["excluded"]}
+    assert excluded == {"b.mrc"}
+
+
+def test_save_exclusions_never_accumulates_across_calls(tmp_path):
+    """Each save re-derives from the ORIGINAL input, not the job's own
+    already-trimmed copy -- so excluding {b} then excluding {c} must leave
+    ONLY c excluded (b re-included), not both."""
+    project = _project(tmp_path, series={
+        "TS_01": (["a.mrc", "b.mrc", "c.mrc"], [0.0, 3.0, -3.0]),
+    })
+    job_dir = project / "ExcludeTiltImages" / "job003"
+    exclude_tilts.save_tilt_series_exclusions(project, job_dir, IN_TILTSERIES, "TS_01", ["b.mrc"])
+    exclude_tilts.save_tilt_series_exclusions(project, job_dir, IN_TILTSERIES, "TS_01", ["c.mrc"])
+    images = exclude_tilts.list_images(project, job_dir, IN_TILTSERIES, "TS_01")
+    excluded = {i["movie_name"] for i in images if i["excluded"]}
+    assert excluded == {"c.mrc"}
+
+
+def test_save_exclusions_all_images_leaves_zero_rows_but_keeps_job_star(tmp_path):
+    project = _project(tmp_path, series={"TS_01": (["a.mrc", "b.mrc"], [0.0, 3.0])})
+    job_dir = project / "ExcludeTiltImages" / "job003"
+    result = exclude_tilts.save_tilt_series_exclusions(
+        project, job_dir, IN_TILTSERIES, "TS_01", ["a.mrc", "b.mrc"])
+    assert result["n_kept"] == 0
+    df = starfile.read(Path(result["series_path"]), always_dict=True)["TS_01"]
+    assert len(df) == 0
+    gdf = starfile.read(job_dir / "selected_tilt_series.star", always_dict=True)["global"]
+    assert list(gdf["rlnTomoName"]) == ["TS_01"]
+
+
+def test_save_exclusions_one_series_does_not_disturb_another(tmp_path):
+    project = _project(tmp_path, series={
+        "TS_01": (["a.mrc", "b.mrc"], [0.0, 3.0]),
+        "TS_02": (["x.mrc", "y.mrc"], [0.0, 3.0]),
+    })
+    job_dir = project / "ExcludeTiltImages" / "job003"
+    exclude_tilts.write_passthrough(project, job_dir, IN_TILTSERIES)
+    exclude_tilts.save_tilt_series_exclusions(project, job_dir, IN_TILTSERIES, "TS_01", ["a.mrc"])
+
+    ts02_images = exclude_tilts.list_images(project, job_dir, IN_TILTSERIES, "TS_02")
+    assert all(not i["excluded"] for i in ts02_images)
+    summary = exclude_tilts.series_summary(project, job_dir, IN_TILTSERIES)
+    assert {s["name"]: s["n_excluded"] for s in summary} == {"TS_01": 1, "TS_02": 0}
+
+
+# --------------------------------------------------------------------------
+# clear_exclusions
+# --------------------------------------------------------------------------
+
+
+def test_clear_exclusions_removes_everything(tmp_path):
+    project = _project(tmp_path, series={
+        "TS_01": (["a.mrc"], [0.0]), "TS_02": (["x.mrc"], [0.0]),
+    })
+    job_dir = project / "ExcludeTiltImages" / "job003"
+    exclude_tilts.write_passthrough(project, job_dir, IN_TILTSERIES)
+    removed = exclude_tilts.clear_exclusions(job_dir)
+    assert removed == 3  # global star + 2 per-series files
+    assert not (job_dir / "selected_tilt_series.star").exists()
+    assert not (job_dir / "tilt_series").exists()
+
+
+def test_clear_exclusions_on_a_fresh_job_dir_is_a_noop(tmp_path):
+    job_dir = tmp_path / "ExcludeTiltImages" / "job001"
+    job_dir.mkdir(parents=True)
+    assert exclude_tilts.clear_exclusions(job_dir) == 0

--- a/backend/tests/test_exclude_tilts.py
+++ b/backend/tests/test_exclude_tilts.py
@@ -71,6 +71,27 @@ def test_list_tilt_series_missing_star_raises(tmp_path):
         exclude_tilts.list_tilt_series(tmp_path, "nope.star")
 
 
+def test_purely_numeric_tomo_name_survives_round_trip(tmp_path):
+    """rlnTomoName is free text in real RELION-5 tomography STAR files, and
+    some projects name tomograms with plain digits (e.g. "01") -- without
+    parse_as_string, starfile/pandas would infer an int column, silently
+    turning "01" into 1 and breaking every name-keyed lookup in this
+    module."""
+    project = _project(tmp_path, series={"01": (["a.mrc", "b.mrc"], [0.0, 3.0])})
+    assert exclude_tilts.list_tilt_series(project, IN_TILTSERIES) == ["01"]
+    job_dir = project / "ExcludeTiltImages" / "job003"
+    exclude_tilts.write_passthrough(project, job_dir, IN_TILTSERIES)
+    # Read back the way exclude_tilts.py itself reads (parse_as_string on
+    # rlnTomoName) -- a raw starfile.read of the on-disk STAR text, with no
+    # such hint, would infer this column as int (same ambiguity real
+    # RELION's own STAR reader has to guard against), which is exactly the
+    # bug this test exists to catch.
+    gdf = exclude_tilts._read_star_blocks(job_dir / "selected_tilt_series.star")["global"]
+    assert list(gdf["rlnTomoName"]) == ["01"]
+    images = exclude_tilts.list_images(project, job_dir, IN_TILTSERIES, "01")
+    assert len(images) == 2
+
+
 def test_list_images_before_any_save_reports_nothing_excluded(tmp_path):
     project = _project(tmp_path, series={
         "TS_01": (["a.mrc", "b.mrc", "c.mrc"], [0.0, 3.0, -3.0]),
@@ -178,7 +199,14 @@ def test_save_exclusions_never_accumulates_across_calls(tmp_path):
     assert excluded == {"c.mrc"}
 
 
-def test_save_exclusions_all_images_leaves_zero_rows_but_keeps_job_star(tmp_path):
+def test_save_exclusions_all_images_leaves_zero_rows_and_drops_from_global_star(tmp_path):
+    """A fully-excluded tilt series must be DROPPED from the job's global
+    selected_tilt_series.star -- matching real RELION's own RlnTiltSeriesSet.
+    write_star_file, which never emits a row for an empty tilt series (a
+    downstream job has nothing to do with a series that has no images
+    left). The per-series STAR itself is still written, with zero rows --
+    that's what lets list_images/series_summary tell "fully excluded" apart
+    from "never touched"."""
     project = _project(tmp_path, series={"TS_01": (["a.mrc", "b.mrc"], [0.0, 3.0])})
     job_dir = project / "ExcludeTiltImages" / "job003"
     result = exclude_tilts.save_tilt_series_exclusions(
@@ -186,8 +214,21 @@ def test_save_exclusions_all_images_leaves_zero_rows_but_keeps_job_star(tmp_path
     assert result["n_kept"] == 0
     df = starfile.read(Path(result["series_path"]), always_dict=True)["TS_01"]
     assert len(df) == 0
-    gdf = starfile.read(job_dir / "selected_tilt_series.star", always_dict=True)["global"]
-    assert list(gdf["rlnTomoName"]) == ["TS_01"]
+    assert not (job_dir / "selected_tilt_series.star").exists()
+
+
+def test_list_images_all_excluded_after_fully_excluding_a_series(tmp_path):
+    """Regression: once a series has been explicitly fully excluded (empty
+    per-series STAR written, see above), list_images must show every image
+    as excluded -- not silently default back to "kept" just because the
+    tomogram's row is gone from the global star."""
+    project = _project(tmp_path, series={"TS_01": (["a.mrc", "b.mrc"], [0.0, 3.0])})
+    job_dir = project / "ExcludeTiltImages" / "job003"
+    exclude_tilts.save_tilt_series_exclusions(project, job_dir, IN_TILTSERIES, "TS_01", ["a.mrc", "b.mrc"])
+    images = exclude_tilts.list_images(project, job_dir, IN_TILTSERIES, "TS_01")
+    assert all(i["excluded"] for i in images)
+    summary = exclude_tilts.series_summary(project, job_dir, IN_TILTSERIES)
+    assert {s["name"]: s["n_excluded"] for s in summary} == {"TS_01": 2}
 
 
 def test_save_exclusions_one_series_does_not_disturb_another(tmp_path):
@@ -220,6 +261,54 @@ def test_clear_exclusions_removes_everything(tmp_path):
     assert removed == 3  # global star + 2 per-series files
     assert not (job_dir / "selected_tilt_series.star").exists()
     assert not (job_dir / "tilt_series").exists()
+
+
+def test_reset_and_write_passthrough_is_atomic_under_a_concurrent_save(tmp_path):
+    """A save request racing job start's clear+reseed (both run on their own
+    threads -- see main.py's plain `def` endpoints and custom_jobs.
+    run_exclude_tilt_images's asyncio.to_thread) must never observe a
+    half-cleared job directory or corrupt the global star. Runs
+    reset_and_write_passthrough and save_tilt_series_exclusions from real
+    threads many times over and checks the global star is always
+    well-formed and never loses a series that a passthrough write is
+    responsible for."""
+    import threading
+
+    project = _project(tmp_path, series={
+        "TS_01": (["a.mrc", "b.mrc"], [0.0, 3.0]),
+        "TS_02": (["x.mrc", "y.mrc"], [0.0, 3.0]),
+    })
+    job_dir = project / "ExcludeTiltImages" / "job003"
+    exclude_tilts.write_passthrough(project, job_dir, IN_TILTSERIES)
+
+    errors = []
+
+    def reset():
+        try:
+            for _ in range(20):
+                exclude_tilts.reset_and_write_passthrough(project, job_dir, IN_TILTSERIES)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    def save():
+        try:
+            for _ in range(20):
+                exclude_tilts.save_tilt_series_exclusions(project, job_dir, IN_TILTSERIES, "TS_02", ["x.mrc"])
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=reset), threading.Thread(target=save)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    # Whatever the final interleaving, the global star must still be a
+    # well-formed STAR with a row per tilt series that has kept images --
+    # never a partial/corrupted table missing an unrelated series.
+    gdf = exclude_tilts._read_star_blocks(job_dir / "selected_tilt_series.star")["global"]
+    assert set(gdf["rlnTomoName"]) <= {"TS_01", "TS_02"}
 
 
 def test_clear_exclusions_on_a_fresh_job_dir_is_a_noop(tmp_path):

--- a/backend/tests/test_job_registry.py
+++ b/backend/tests/test_job_registry.py
@@ -185,13 +185,19 @@ def test_tomo_import_dose_is_per_movie_frame_gets_dropdown_labels():
     assert "boolean_labels" not in raw_opt
 
 
-def test_tomo_exclude_tilt_images_maps_its_hyphenated_flags():
-    d = job_registry.build_job_definition("TomoExcludeTiltImages")
-    draft = d["draft_command"]
-    assert "--cache-size" in draft, draft
-    # in_tiltseries has an empty default so no value is emitted, but the key
-    # must be mapped (not flagged unmapped) via the overlay.
-    assert "in_tiltseries" not in d["unmapped_fields"], d["unmapped_fields"]
+def test_tomo_exclude_tilt_images_is_not_a_draftable_subprocess_job():
+    """TomoExcludeTiltImages moved to custom_jobs.CUSTOM_JOB_DEFINITIONS
+    (job_catalog.CUSTOM_JOBS) -- its real program, relion_tomo_exclude_tilt_
+    images, opens a napari desktop window unconditionally (no headless flag
+    at all), so it can no longer be drafted/run as a subprocess the way
+    build_job_definition()/JOB_CATALOG assume. See exclude_tilts.py /
+    custom_jobs.py for how it's actually run now (the same "moved to
+    CUSTOM_JOBS" treatment TomoImport's hyphenated-flag test above still
+    covers for OTHER tomo jobs that stayed real subprocesses)."""
+    with pytest.raises(KeyError):
+        job_registry.build_job_definition("TomoExcludeTiltImages")
+    from custom_jobs import CUSTOM_JOB_DEFINITIONS
+    assert "TomoExcludeTiltImages" in CUSTOM_JOB_DEFINITIONS
 
 
 def test_extractor_regex_captures_full_hyphenated_flags():

--- a/backend/tests/test_main_endpoints.py
+++ b/backend/tests/test_main_endpoints.py
@@ -26,6 +26,9 @@ import httpx2
 import pytest
 from fastapi.testclient import TestClient
 
+pd = pytest.importorskip("pandas")
+starfile = pytest.importorskip("starfile")
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import main
@@ -88,6 +91,31 @@ def client(tmp_path, monkeypatch):
     project_manager.init_new_project(project_dir)
     main.run_manager.set_project_dir(project_dir)
     return TestClient(main.app)
+
+
+@pytest.fixture
+def picker_client(tmp_path, monkeypatch):
+    """Same wiring as `client` above, but enters TestClient's own context
+    manager so its blocking portal (and the event loop it owns) persists
+    across requests within one test.
+
+    Needed specifically for a picker-style custom job (TomoExcludeTiltImages
+    here): start_custom_job schedules its work as a fire-and-forget
+    `asyncio.create_task`. Against the plain `client` fixture (never
+    entered as `with TestClient(...) as client:`), Starlette's TestClient
+    spins up a FRESH portal+event loop for every individual request and
+    tears it down as soon as that request returns -- which cancels any
+    task still in flight. Confirmed for real: the run landed in "aborted"
+    ("Aborted by user.") within about a millisecond of being started,
+    every time. Real subprocess jobs elsewhere in this file don't hit
+    this (their OS-level process runs/exits independent of asyncio task
+    supervision), so `client` stays exactly as it was for them."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg_config"))
+    project_dir = tmp_path / "project"
+    project_manager.init_new_project(project_dir)
+    main.run_manager.set_project_dir(project_dir)
+    with TestClient(main.app) as test_client:
+        yield test_client
 
 
 @pytest.fixture
@@ -562,3 +590,116 @@ def test_terminal_websocket_refuses_connection_when_auth_enabled_without_session
                 pass
     finally:
         auth.disable()
+
+
+# ---------------------------------------------------------------------------
+# Exclude Tilt Images (TomoExcludeTiltImages) -- HTTP-level coverage for the
+# /api/exclude-tilts/* routes the reviewer popup actually calls. Module-level
+# STAR-writing coverage lives in test_exclude_tilts.py; this only exercises
+# the route wiring (run_id -> job dir/input resolution, status codes).
+# ---------------------------------------------------------------------------
+
+
+def _seed_tilt_series_project(project_dir):
+    """A CtfFind-shaped global tilt-series-set star + one per-series star,
+    the same minimal shape test_exclude_tilts.py's own `_project` fixture
+    uses -- built by hand here (not shared) since this file has its own
+    `client` fixture wiring a different project_dir per test."""
+    ctf_dir = project_dir / "CtfFind" / "job002" / "tilt_series"
+    ctf_dir.mkdir(parents=True)
+    series_df = pd.DataFrame({
+        "rlnMicrographMovieName": ["a.mrc", "b.mrc"],
+        "rlnTomoNominalStageTiltAngle": [0.0, 3.0],
+        "rlnMicrographName": ["MotionCorr/job001/a.mrc", "MotionCorr/job001/b.mrc"],
+    })
+    starfile.write({"TS_01": series_df}, ctf_dir / "TS_01.star", overwrite=True)
+    global_df = pd.DataFrame({
+        "rlnTomoName": ["TS_01"],
+        "rlnTomoTiltSeriesStarFile": ["CtfFind/job002/tilt_series/TS_01.star"],
+        "rlnVoltage": [300.0],
+    })
+    starfile.write({"global": global_df}, project_dir / "CtfFind" / "job002" / "tilt_series_ctf.star", overwrite=True)
+    return "CtfFind/job002/tilt_series_ctf.star"
+
+
+def _start_exclude_tilts_run(client):
+    in_tiltseries = _seed_tilt_series_project(main.run_manager.project_dir)
+    resp = client.post("/api/runs", json={
+        "internal_name": "TomoExcludeTiltImages",
+        "field_values": {"in_tiltseries": in_tiltseries},
+    })
+    assert resp.status_code == 200, resp.text
+    run_id = resp.json()["run_id"]
+    # "running" fires the instant the run's background task starts (see
+    # job_runner.JobRunManager._run_custom) -- BEFORE run_exclude_tilt_
+    # images has actually written its initial pass-through output.
+    # stdout_lines only gets its summary line once that coroutine returns,
+    # so waiting for both means the pass-through write has genuinely
+    # finished before this helper hands back a run_id to save/list against
+    # -- otherwise a save() issued too early can race the still-in-flight
+    # pass-through write and be silently clobbered by it.
+    deadline = time.monotonic() + 5.0
+    last = None
+    while time.monotonic() < deadline:
+        last = client.get(f"/api/runs/{run_id}").json()
+        if last.get("status") in ("running", "failed") and last.get("stdout_lines"):
+            break
+        time.sleep(0.02)
+    assert last["status"] == "running", last
+    return run_id
+
+
+def test_exclude_tilts_series_and_images_list_the_passthrough_default(picker_client):
+    run_id = _start_exclude_tilts_run(picker_client)
+
+    series = picker_client.get(f"/api/exclude-tilts/{run_id}/series")
+    assert series.status_code == 200
+    assert series.json() == {"series": [{"name": "TS_01", "n_images": 2, "n_excluded": 0}]}
+
+    images = picker_client.get(f"/api/exclude-tilts/{run_id}/images", params={"tomo_name": "TS_01"})
+    assert images.status_code == 200
+    body = images.json()["images"]
+    assert [i["movie_name"] for i in body] == ["a.mrc", "b.mrc"]
+    assert all(not i["excluded"] for i in body)
+
+
+def test_exclude_tilts_save_then_series_reflects_the_exclusion(picker_client):
+    run_id = _start_exclude_tilts_run(picker_client)
+
+    saved = picker_client.post(f"/api/exclude-tilts/{run_id}/save", json={
+        "tomo_name": "TS_01", "excluded_movie_names": ["a.mrc"],
+    })
+    assert saved.status_code == 200, saved.text
+    assert saved.json()["n_excluded"] == 1
+
+    series = picker_client.get(f"/api/exclude-tilts/{run_id}/series").json()["series"]
+    assert series == [{"name": "TS_01", "n_images": 2, "n_excluded": 1}]
+
+    images = picker_client.get(f"/api/exclude-tilts/{run_id}/images", params={"tomo_name": "TS_01"}).json()["images"]
+    assert [i["movie_name"] for i in images if i["excluded"]] == ["a.mrc"]
+
+
+def test_exclude_tilts_images_unknown_tomogram_is_400(picker_client):
+    run_id = _start_exclude_tilts_run(picker_client)
+    resp = picker_client.get(f"/api/exclude-tilts/{run_id}/images", params={"tomo_name": "NOPE"})
+    assert resp.status_code == 400
+
+
+def test_exclude_tilts_unknown_run_id_404s(client):
+    resp = client.get("/api/exclude-tilts/no-such-run/series")
+    assert resp.status_code == 404
+
+
+def test_exclude_tilts_done_button_completes_it_like_a_picker_job(picker_client):
+    """TomoExcludeTiltImages is is_picker=True, so it shares Manualpick's
+    Done/Continue lifecycle (see test_custom_jobs.py for the STAR-writing
+    side) -- this just confirms the SAME /api/runs/{id}/resume gate that
+    used to say "only Manualpick/TomoManualPick" now also accepts it."""
+    run_id = _start_exclude_tilts_run(picker_client)
+    done = picker_client.patch(f"/api/runs/{run_id}", json={"status": "completed"})
+    assert done.status_code == 200
+    assert done.json()["status"] == "completed"
+
+    resumed = picker_client.post(f"/api/runs/{run_id}/resume")
+    assert resumed.status_code == 200
+    assert resumed.json()["status"] == "running"

--- a/backend/tests/verify_draft_flags_against_relion.py
+++ b/backend/tests/verify_draft_flags_against_relion.py
@@ -53,7 +53,9 @@ JOB_HELP_TARGETS: dict[str, list[tuple[Path, str, list[str]]]] = {
     "TomoAlign": [(BIN_DIR, "relion_tomo_align", [])],
     "TomoReconPart": [(BIN_DIR, "relion_tomo_reconstruct_particle", [])],
     "TomoImport": [(CONDA_BIN_DIR, "relion_tomo_import", ["SerialEM"])],
-    "TomoExcludeTiltImages": [(CONDA_BIN_DIR, "relion_tomo_exclude_tilt_images", [])],
+    # TomoExcludeTiltImages has no entry here -- it moved to CUSTOM_JOBS (see
+    # job_catalog.py), so DRAFT_OVERRIDES no longer has anything to verify
+    # for it (this script only iterates DRAFT_OVERRIDES.items()).
     # Motioncorr's --help exits before printing usage (it errors out demanding
     # --use_motioncor2 / RELION's own implementation be chosen first); its
     # flags are checked against source instead, via SOURCE_FALLBACK below.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -636,9 +636,13 @@ async function openJobPopup(internalName, displayName, existingRun, opts = {}) {
       <button class="btn" data-action="collapse" title="Minimize this window">− Collapse</button>
       <button class="btn" data-action="close" title="Close this window">✕ Close</button>
       <button class="btn" data-action="note" title="Edit note">📝 Note</button>
-      ${def.is_picker ? '<button class="btn primary" data-action="picker" hidden title="Open the in-browser picker for this job — double-click to add a pick, right-click to delete one">🔍 Open Picker</button>' : ""}
-      ${def.is_picker ? '<button class="btn" data-action="continue-picking" hidden title="Resume this picking session — keeps every pick already saved">▶ Continue</button>' : ""}
-      <button class="btn" data-action="overwrite" hidden title="${def.is_picker ? "Start a NEW picking session in this same job — deletes every pick already saved here. Use Continue instead to keep them." : "Re-run into this SAME output directory, overwriting its files (RELION's 'Overwrite' job action)"}">⟳ Overwrite</button>
+      ${def.is_picker ? `<button class="btn primary" data-action="picker" hidden title="${
+        def.picker_kind === "excludetilts"
+          ? "Open the in-browser tilt-image reviewer for this job — check/uncheck images to exclude them"
+          : "Open the in-browser picker for this job — double-click to add a pick, right-click to delete one"
+      }">${def.picker_kind === "excludetilts" ? "🔍 Open Reviewer" : "🔍 Open Picker"}</button>` : ""}
+      ${def.is_picker ? `<button class="btn" data-action="continue-picking" hidden title="Resume this ${def.picker_kind === "excludetilts" ? "review" : "picking"} session — keeps everything already saved">▶ Continue</button>` : ""}
+      <button class="btn" data-action="overwrite" hidden title="${def.is_picker ? `Start a NEW ${def.picker_kind === "excludetilts" ? "review" : "picking"} session in this same job — discards everything already saved here. Use Continue instead to keep it.` : "Re-run into this SAME output directory, overwriting its files (RELION's 'Overwrite' job action)"}">⟳ Overwrite</button>
       <button class="btn" data-action="clone" hidden title="Open a new job of this type, pre-filled with these same settings — a fresh job with its own new number, not tied to this one">⎘ Clone</button>
       <button class="btn" data-action="abort" hidden title="Stop this running job">⏹ Abort</button>
       <button class="btn" data-action="mark-finished" hidden title="Manually mark as finished">✓ Mark Finished</button>
@@ -668,7 +672,7 @@ async function openJobPopup(internalName, displayName, existingRun, opts = {}) {
     <div class="command-row active" data-role="command-row">
       <div class="command-actions">
         <button class="btn primary" data-role="run-btn">Run</button>
-        ${def.is_picker ? '<button class="btn primary" data-role="done-btn" hidden title="Finish this picking session — marks the job complete, including in RELION\'s own pipeline">✓ Done</button>' : ""}
+        ${def.is_picker ? `<button class="btn primary" data-role="done-btn" hidden title="Finish this ${def.picker_kind === "excludetilts" ? "review" : "picking"} session — marks the job complete, including in RELION's own pipeline">✓ Done</button>` : ""}
         <span class="status-line" data-role="status-line"></span>
       </div>
     </div>` : `
@@ -1273,16 +1277,21 @@ async function openJobPopup(internalName, displayName, existingRun, opts = {}) {
   if (pickerBtn) {
     pickerBtn.addEventListener("click", () => {
       if (!currentRun) return;
-      const sourceKey = def.picker_kind === "spa" ? "fn_in" : "in_tomoset";
+      const kind = def.picker_kind;
+      const sourceKey = kind === "spa" ? "fn_in" : kind === "excludetilts" ? "in_tiltseries" : "in_tomoset";
       const sourcePath = (currentRun.field_values || {})[sourceKey];
       if (!sourcePath) {
-        errorDialog(
-          `This job has no ${sourceKey === "fn_in" ? "input micrographs" : "input tomograms.star"} `
-          + `recorded to pick against.`
-        );
+        const label = sourceKey === "fn_in" ? "input micrographs"
+          : sourceKey === "in_tiltseries" ? "input tilt series STAR"
+          : "input tomograms.star";
+        errorDialog(`This job has no ${label} recorded to pick against.`);
         return;
       }
-      openVisualizer({ runId: currentRun.run_id, kind: def.picker_kind, sourcePath });
+      if (kind === "excludetilts") {
+        openExcludeTiltsEditor({ runId: currentRun.run_id, sourcePath });
+      } else {
+        openVisualizer({ runId: currentRun.run_id, kind, sourcePath });
+      }
     });
   }
 
@@ -4652,6 +4661,164 @@ async function openVisualizer(pickingContext = null) {
 }
 
 document.getElementById("visualizeBtn").addEventListener("click", () => openVisualizer());
+
+// ---- Exclude Tilt Images: the in-browser tilt-image reviewer ------------
+// Opened from a TomoExcludeTiltImages job popup's "Open Reviewer" button
+// (def.picker_kind === "excludetilts" -- see openJobPopup's pickerBtn
+// wiring). Replaces relion_tomo_exclude_tilt_images' own napari desktop
+// window (no headless flag at all) with a plain checklist: one tilt series
+// at a time, each of its images as a thumbnail + checkbox row. Checked =
+// kept, unchecked = excluded -- Save posts the FULL current checkbox state
+// for that series (not a diff), matching exclude_tilts.py's own
+// "always re-derive from the original input" contract (see its module
+// docstring), so there's no accumulation across saves and re-checking a
+// previously-excluded image genuinely re-includes it.
+async function openExcludeTiltsEditor({ runId, sourcePath }) {
+  const body = document.createElement("div");
+  body.className = "xt-popup";
+  body.innerHTML = `
+    <aside class="xt-series-list" data-role="xt-series-list">
+      <div class="xt-hint">Loading tilt series…</div>
+    </aside>
+    <div class="xt-main">
+      <div class="xt-toolbar">
+        <span class="xt-series-title" data-role="xt-series-title">Select a tilt series</span>
+        <div class="xt-toolbar-actions">
+          <button type="button" class="btn btn-sm" data-role="xt-select-all">Include all</button>
+          <button type="button" class="btn btn-sm" data-role="xt-select-none">Exclude all</button>
+          <button type="button" class="btn primary btn-sm" data-role="xt-save">💾 Save exclusions</button>
+        </div>
+      </div>
+      <div class="status-line xt-status" data-role="xt-status"></div>
+      <div class="xt-image-list" data-role="xt-image-list">
+        <div class="xt-hint">Pick a tilt series on the left to review its images.</div>
+      </div>
+    </div>
+  `;
+
+  const q = (sel) => body.querySelector(sel);
+  const seriesListEl = q('[data-role="xt-series-list"]');
+  const seriesTitleEl = q('[data-role="xt-series-title"]');
+  const statusEl = q('[data-role="xt-status"]');
+  const imageListEl = q('[data-role="xt-image-list"]');
+
+  let seriesList = [];   // [{name, n_images, n_excluded}]
+  let currentName = null;
+  let currentImages = []; // last-loaded images for currentName
+
+  function renderSeriesList() {
+    seriesListEl.innerHTML = seriesList.map((s) => `
+      <button type="button" class="xt-series-row ${s.name === currentName ? "active" : ""}" data-name="${escapeHtml(s.name)}">
+        <span class="xt-series-name">${escapeHtml(s.name)}</span>
+        <span class="xt-series-badge ${s.n_excluded > 0 ? "xt-series-badge-warn" : ""}">${s.n_images - s.n_excluded}/${s.n_images}</span>
+      </button>
+    `).join("");
+    seriesListEl.querySelectorAll(".xt-series-row").forEach((btn) => {
+      btn.addEventListener("click", () => loadSeries(btn.dataset.name));
+    });
+  }
+
+  async function refreshSeriesList() {
+    const resp = await api(`/api/exclude-tilts/${runId}/series`);
+    seriesList = resp.series || [];
+    renderSeriesList();
+  }
+
+  function renderImages() {
+    if (!currentImages.length) {
+      imageListEl.innerHTML = '<div class="xt-hint">No images in this tilt series.</div>';
+      return;
+    }
+    imageListEl.innerHTML = currentImages.map((img, i) => `
+      <label class="xt-image-row ${img.excluded ? "xt-excluded" : ""}" data-index="${i}">
+        <input type="checkbox" data-role="xt-check" ${img.excluded ? "" : "checked"} />
+        ${img.mic_name
+          ? `<img class="xt-thumb" loading="lazy" alt="" src="/api/viz/slice?mrc_path=${encodeURIComponent(img.mic_name)}&axis=z&index=0&max_dim=160" />`
+          : '<span class="xt-thumb xt-thumb-missing"></span>'}
+        <span class="xt-image-meta">
+          <span class="xt-angle">${img.tilt_angle === null || img.tilt_angle === undefined ? "?" : img.tilt_angle.toFixed(1)}°</span>
+          <span class="xt-sub">${[
+            img.pre_exposure !== null && img.pre_exposure !== undefined ? `dose ${img.pre_exposure.toFixed(1)} e⁻/Å²` : null,
+            img.ctf_max_resolution !== null && img.ctf_max_resolution !== undefined ? `CTF ${img.ctf_max_resolution.toFixed(1)} Å` : null,
+            img.accum_motion_total !== null && img.accum_motion_total !== undefined ? `motion ${img.accum_motion_total.toFixed(1)} Å` : null,
+          ].filter(Boolean).join(" · ")}</span>
+        </span>
+      </label>
+    `).join("");
+    imageListEl.querySelectorAll(".xt-image-row").forEach((row) => {
+      const checkbox = row.querySelector('[data-role="xt-check"]');
+      checkbox.addEventListener("change", () => row.classList.toggle("xt-excluded", !checkbox.checked));
+    });
+  }
+
+  async function loadSeries(name) {
+    currentName = name;
+    renderSeriesList();
+    seriesTitleEl.textContent = name;
+    statusEl.textContent = "Loading images…";
+    imageListEl.innerHTML = "";
+    try {
+      const resp = await api(`/api/exclude-tilts/${runId}/images?tomo_name=${encodeURIComponent(name)}`);
+      currentImages = resp.images || [];
+      renderImages();
+      statusEl.textContent = `${currentImages.length} image(s).`;
+    } catch (err) {
+      statusEl.textContent = "Error: " + err.message;
+    }
+  }
+
+  q('[data-role="xt-select-all"]').addEventListener("click", () => {
+    imageListEl.querySelectorAll('[data-role="xt-check"]').forEach((cb) => {
+      cb.checked = true;
+      cb.closest(".xt-image-row").classList.remove("xt-excluded");
+    });
+  });
+  q('[data-role="xt-select-none"]').addEventListener("click", () => {
+    imageListEl.querySelectorAll('[data-role="xt-check"]').forEach((cb) => {
+      cb.checked = false;
+      cb.closest(".xt-image-row").classList.add("xt-excluded");
+    });
+  });
+
+  q('[data-role="xt-save"]').addEventListener("click", async () => {
+    if (!currentName || !currentImages.length) return;
+    statusEl.textContent = "Saving…";
+    const rows = imageListEl.querySelectorAll(".xt-image-row");
+    const excludedMovieNames = [];
+    rows.forEach((row) => {
+      const i = Number(row.dataset.index);
+      const checked = row.querySelector('[data-role="xt-check"]').checked;
+      if (!checked) excludedMovieNames.push(currentImages[i].movie_name);
+    });
+    try {
+      const result = await api(`/api/exclude-tilts/${runId}/save`, {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tomo_name: currentName, excluded_movie_names: excludedMovieNames }),
+      });
+      statusEl.textContent = `Saved: ${result.n_kept}/${result.n_total} kept.`;
+      await refreshSeriesList();
+      await loadSeries(currentName);
+    } catch (err) {
+      statusEl.textContent = "Error: " + err.message;
+    }
+  });
+
+  try {
+    await refreshSeriesList();
+    if (seriesList.length) await loadSeries(seriesList[0].name);
+    else seriesListEl.innerHTML = `<div class="xt-hint">No tilt series found in ${escapeHtml(sourcePath)}.</div>`;
+  } catch (err) {
+    seriesListEl.innerHTML = `<div class="xt-hint">Error: ${escapeHtml(err.message)}</div>`;
+  }
+
+  new WinBox({
+    title: "Exclude Tilt Images",
+    width: "1040px", height: "800px",
+    x: "center", y: "center",
+    mount: body,
+    class: ["viz-winbox"],
+  });
+}
 
 // ==========================================================================
 // Server-side FILE picker.

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -937,6 +937,61 @@ html, body {
 }
 .viz-check { display: flex; align-items: center; gap: 5px; font-size: 11px; }
 
+/* ---- Exclude Tilt Images reviewer ----
+   A tilt-series list on the left, a scrolling checklist of that series' own
+   images (thumbnail + tilt angle/dose/CTF/motion) on the right. Checked =
+   kept, unchecked = excluded -- see openExcludeTiltsEditor in app.js. */
+.xt-popup {
+  display: flex; flex-direction: row; gap: 10px;
+  padding: 10px; height: 100%; box-sizing: border-box; min-height: 0;
+}
+.xt-series-list {
+  width: 200px; flex-shrink: 0;
+  display: flex; flex-direction: column; gap: 2px;
+  overflow-y: auto; padding-right: 2px;
+}
+.xt-series-row {
+  display: flex; align-items: center; justify-content: space-between; gap: 6px;
+  padding: 6px 8px; border-radius: 4px; border: 1px solid transparent;
+  background: none; color: var(--text); font-size: 12px; text-align: left;
+  cursor: pointer;
+}
+.xt-series-row:hover { background: var(--accent-dim); }
+.xt-series-row.active { background: var(--panel-alt); border-color: var(--border); font-weight: 600; }
+.xt-series-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.xt-series-badge {
+  flex-shrink: 0; font-size: 10px; color: var(--text-dim);
+  padding: 1px 6px; border-radius: 8px; background: var(--panel-alt);
+}
+.xt-series-badge-warn { color: var(--err); }
+.xt-main { flex: 1; display: flex; flex-direction: column; min-width: 0; min-height: 0; gap: 6px; }
+.xt-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; flex-wrap: wrap; }
+.xt-series-title { font-weight: 600; font-size: 13px; }
+.xt-toolbar-actions { display: flex; gap: 6px; }
+.xt-status { min-height: 14px; }
+.xt-hint { font-size: 11px; color: var(--text-dim); padding: 8px 2px; }
+.xt-image-list {
+  flex: 1; min-height: 0; overflow-y: auto;
+  display: flex; flex-direction: column; gap: 2px;
+}
+.xt-image-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 5px 8px; border-radius: 4px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+}
+.xt-image-row:hover { background: var(--accent-dim); }
+.xt-image-row.xt-excluded { opacity: 0.45; }
+.xt-image-row.xt-excluded .xt-angle { text-decoration: line-through; }
+.xt-thumb {
+  width: 64px; height: 64px; object-fit: cover; flex-shrink: 0;
+  background: #000; border-radius: 3px;
+}
+.xt-thumb-missing { display: inline-block; }
+.xt-image-meta { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.xt-angle { font-size: 13px; font-weight: 600; }
+.xt-sub { font-size: 11px; color: var(--text-dim); }
+
 /* ---- Job Progress tab (live charts + class thumbnails) ---- */
 /* The Progress tab is a top/bottom split (charts above, the classic
    scrolling RELION console below -- see appendOutputLine/


### PR DESCRIPTION
## Summary

`TomoExcludeTiltImages` (`relion.excludetilts`) had no way to run from the browser UI: its real program, `relion_tomo_exclude_tilt_images`, unconditionally opens a napari desktop window (`napari.Viewer()` / `napari.run()`) with no headless/non-interactive flag at all — the same problem Manual Picking already solves for `relion_manualpick`. This moves it into the same custom-job architecture.

- **`backend/exclude_tilts.py`** (new) — writes the same `selected_tilt_series.star` + per-series STAR format the real napari widget produces (`RlnTiltSeriesSet`/`RelionTiltImageExcluderWidget.save_output`'s boolean-mask-and-write shape), with no napari/GUI dependency. "Excluded" is derived by comparing the original per-series input against the job's own already-saved copy — no separate state file needed, and re-including a previously excluded image just works (no accumulation across saves).
- **`backend/job_catalog.py`** — moved `TomoExcludeTiltImages` from `JOB_CATALOG` (real subprocess) to `CUSTOM_JOBS`, under its real `relion.excludetilts` label so RELION's own pipeliner still recognizes it, validates it, and computes its real output nodes.
- **`backend/custom_jobs.py`** — new `run_exclude_tilt_images` runner. On start it writes a full pass-through with **nothing excluded** — a legitimate default (unlike an unpicked Manualpick job, which has no particles at all) — so the job's output is immediately valid for downstream jobs (Reconstruct Tomograms, TomoSubtomo, ...) even before anyone opens the reviewer. Shares Manualpick's `is_picker`/`stays_running` semantics (Done/Continue/Overwrite).
- **`backend/main.py`** — three new endpoints (`GET /api/exclude-tilts/{run_id}/series`, `GET .../images`, `POST .../save`), plus a `max_dim` query param on `/api/viz/slice` so the reviewer's per-image thumbnails don't download full 1200px PNGs.
- **`frontend/app.js` / `style.css`** — new `openExcludeTiltsEditor` popup: a tilt-series list on the left, a scrollable checklist of that series' images (thumbnail via the existing MRC→PNG viewer, tilt angle, dose, CTF resolution, motion) on the right, checkbox = kept/excluded.

## Test plan

- [x] `backend/tests/test_exclude_tilts.py` (18 unit tests) — pass-through, save/exclude, re-inclusion (no accumulation), sort-by-tilt-angle, clear-on-overwrite
- [x] `backend/tests/test_custom_jobs.py` — end-to-end via `JobRunManager`: registers under `relion.excludetilts` in RELION's real pipeline, `stays_running` → Done → Continue preserves exclusions, Overwrite clears and re-seeds a fresh pass-through
- [x] `backend/tests/test_main_endpoints.py` — HTTP-level coverage for the three new routes plus the Done/Continue lifecycle
- [x] Full backend suite: 1033 passed
- [x] Live-verified in the browser against a real RELION 5.0.1 tomography tutorial project: ran the job, saw all 5 tilt series pass through untouched, excluded images from TS_01 via checkboxes, saved, confirmed the written STAR files exactly matched the reference `job003` fixture's format, Done → Continue preserved the exclusion state, "Include all" cleanly re-included with no accumulation, and RELION's own `default_pipeline.star` correctly showed the job as `Succeeded` under `relion.excludetilts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)