### PR TITLE
Add HTTPS, scrypt password hashing and login lockout

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ or an HPC login node and open it from any browser on the network — no Qt, no
 X11 forwarding, no display server.
 
 **Contents:** [Why](#why-this-exists) · [Install](#installing-it) ·
-[Running it](#running-it) · [Password](#password-protection) ·
+[Running it](#running-it) · [Security](#security-https-and-the-password) ·
 [Using it](#using-it) · [Job types](#what-jobs-are-available) ·
 [The draft command](#how-the-draft-command-is-built) ·
 [Working alongside RELION](#working-alongside-relions-own-gui) ·
@@ -134,8 +134,9 @@ http://localhost:8420/
 ```
 
 To reach it directly from another machine without a tunnel, opt in explicitly
-with `--host 0.0.0.0` — read [Password protection](#password-protection)
-first, because that's the point at which it starts to matter.
+with `--host 0.0.0.0` — read [Security](#security-https-and-the-password)
+first and turn on `--tls`, because that's the point at which it starts to
+matter.
 
 **You don't have to run it from inside a project directory.** If you `cd` into
 an existing RELION project first, it's picked up automatically; otherwise it
@@ -154,44 +155,129 @@ ln -s "$(pwd)/Run-RelionUS" ~/bin/Run-RelionUS
 sudo ln -s "$(pwd)/Run-RelionUS" /usr/local/bin/Run-RelionUS
 ```
 
-## Password protection
+## Security: HTTPS and the password
 
-RELION-US binds `127.0.0.1` by default, so it isn't reachable from another
-machine unless you opt in with `--host 0.0.0.0`. But even at the default bind,
-anyone who can already reach this machine's localhost — another user on a
-shared login node, say — can open jobs, run them, delete run history, and open
-a full interactive shell through the Terminal popup, with no login at all.
+Two separate things, and they protect against different attacks. **Turn on
+both** if this is reachable from any machine other than the one running it.
 
-A password is available as a basic deterrent against that. It is **not real
-security**: this app sets up no encryption, so the password crosses the
-network in plain text like everything else. If you need actual
-confidentiality, put it behind a reverse proxy (nginx/Caddy) with TLS
-termination, or reach it over the SSH tunnel above.
+### HTTPS (encrypts the connection)
+
+This is the one that matters most, and the one to set up first. Without it
+every byte crosses the network in the clear — the password, your project
+paths, job commands, and anything the Terminal popup shows. How well the
+password is hashed on disk is irrelevant to that: someone on the path reads
+the password itself, not the hash.
+
+```bash
+./Run-RelionUS --make-cert    # generate a certificate and key (once)
+./Run-RelionUS --tls          # serve HTTPS with it
+```
+
+`--make-cert` writes a 4096-bit key and a self-signed certificate into the
+config directory (key mode `0600`), records their paths so plain `--tls` finds
+them later, and prints the certificate's SHA-256 fingerprint. The certificate
+names this host plus `localhost`/`127.0.0.1`/`::1`, so it works whether you
+reach the app directly or through an SSH tunnel.
+
+**Your browser will warn once that the certificate isn't trusted.** That is
+expected and does not mean the connection is unencrypted — traffic is TLS 1.3
+either way. What a self-signed certificate can't do is *prove which server you
+reached*, which is the one thing a certificate authority sells. Two ways to
+close that gap:
+
+- Compare the fingerprint the browser shows against the SHA-256 that
+  `--make-cert` printed. If they match, there's no one in the middle. Do this
+  the first time and the exception is remembered.
+- Or use a real certificate — from your institution, or Let's Encrypt — and
+  skip the warning entirely:
+  ```bash
+  ./Run-RelionUS --tls-cert /path/fullchain.pem --tls-key /path/privkey.pem
+  ```
+
+With a real CA-issued certificate you can also add `--hsts`, which tells
+browsers to refuse plain HTTP to this host for a year. Deliberately off by
+default and **not** recommended with a self-signed certificate: it's a
+one-way door that will lock you out of `http://` on that hostname while
+you're still evaluating.
+
+A TLS-terminating reverse proxy (nginx/Caddy) in front of the app also works
+and is a perfectly good choice if you already run one. The app reads
+`X-Forwarded-Proto`, so the session cookie is still marked `Secure` in that
+setup.
+
+**Alternative: an SSH tunnel.** If you'd rather not manage certificates at
+all, leave the default `--host 127.0.0.1` and tunnel — SSH provides the
+encryption, and this is the setup the [Running it](#running-it) section
+describes:
+
+```bash
+ssh -L 8420:localhost:8420 <host>
+```
+
+### The password (proves who is connecting)
+
+Encryption stops eavesdropping; it doesn't stop the person on the next
+workstation opening the page. Even at the localhost-only default bind, anyone
+who can already reach this machine's localhost — another user on a shared HPC
+login node — can open jobs, run them, delete history, and get an interactive
+shell through the Terminal popup, with no login at all.
 
 Every time `Run-RelionUS` starts at an interactive terminal without protection
 already on, it offers to set one up. Decline and it asks again next time
-rather than staying quiet forever. Otherwise it's all terminal flags, on the
-machine running the backend — deliberately with no in-browser way to turn it
-on or change it, since anyone who can already reach a shell there can read and
-edit project files directly anyway:
+rather than staying quiet forever. Otherwise it's terminal flags, on the
+machine running the backend — deliberately with no in-browser way to change
+it, since anyone who can already reach a shell there can edit project files
+directly anyway:
 
 ```bash
 ./Run-RelionUS --set-password   # set/change it (hidden input, twice to confirm)
 ./Run-RelionUS --enable-auth    # require it from now on, every run
 ./Run-RelionUS --disable-auth   # stop requiring it (password kept, not deleted)
-./Run-RelionUS --auth-status    # what's set, and whether it's currently on
+./Run-RelionUS --auth-status    # what's set, how it's hashed, and TLS state
 ./Run-RelionUS --auth           # force it ON for just this one run
 ./Run-RelionUS --no-auth        # force it OFF for just this one run
 ```
 
-Changing the password logs out every existing session at once, on every
-device — there's no separate "log everyone out" step. Sessions otherwise last
-30 days.
+How the password is protected:
 
-When it's on, anyone opening the app lands on a login page first, and the
-password gates every page, every API call, and both websockets (live job
+- **Stored as a salted [scrypt](https://datatracker.ietf.org/doc/html/rfc7914)
+  hash** (n=2¹⁵, r=8, p=1 — RFC 7914's own interactive-login parameters,
+  ~32 MB and ~0.12 s per guess), never in the clear. scrypt is *memory*-hard,
+  which is what makes bulk GPU or ASIC guessing expensive rather than merely
+  slow. It's stdlib, so this adds no dependency.
+- **Upgrades itself.** An instance set up before this used PBKDF2-SHA256; that
+  hash still verifies and is quietly re-hashed to scrypt the next time you log
+  in successfully. Nobody has to reset a password, and `--auth-status` shows
+  which one you're on.
+- **Locked out after repeated failures** — 5 wrong guesses from one address
+  within 5 minutes closes the door for 5 minutes, with a looser global
+  backstop so rotating source addresses doesn't walk around it. The hashing
+  cost only prices *offline* guessing against a stolen config file; 0.12 s per
+  try is no obstacle to a script hammering the login endpoint, so that needs
+  its own control.
+- **Minimum 8 characters**, and the handful of passwords every guessing script
+  tries first are refused. No composition rules — length is what actually
+  predicts guessing cost, and "must contain a symbol" mostly produces
+  `Password1!`, which is in every wordlist.
+- **Session cookie** is `HttpOnly`, `SameSite=lax`, and `Secure` whenever the
+  connection is HTTPS. It's a signed, stateless token, so a backend restart
+  doesn't log everyone out. Sessions last 30 days.
+- **Changing the password logs out every existing session at once**, on every
+  device — there's no separate "log everyone out" step.
+
+The password gates every page, every API call, and both websockets (live job
 output and the Terminal shell), not just the initial page load. A **🔒 Log
-out** item appears under **☰ Menu**.
+out** item appears under **☰ Menu** once you're in.
+
+### What this still isn't
+
+- **One shared password, not user accounts.** There's nothing here to audit
+  who did what — it only answers "did whoever's asking know the password".
+- Responses carry `X-Content-Type-Options`, `X-Frame-Options: DENY` and
+  `Referrer-Policy: same-origin`, and the app sets no CORS policy at all, so
+  another origin can't drive the API. But anyone who *is* logged in can run
+  arbitrary shell commands — that is the app's whole purpose. Treat access to
+  it as equivalent to shell access on that machine.
 
 ## Using it
 
@@ -302,7 +388,7 @@ irreversible one.
 A real interactive shell in the current project directory, in a popup. Handy
 for `module load`, a quick `ls`, or anything the UI doesn't cover. Note that
 this is exactly why the password option exists — see
-[above](#password-protection).
+[above](#security-https-and-the-password).
 
 ## What jobs are available
 

--- a/Run-RelionUS
+++ b/Run-RelionUS
@@ -31,20 +31,34 @@
 #   ln -s "$(pwd)/Run-RelionUS" ~/bin/Run-RelionUS
 #   sudo ln -s "$(pwd)/Run-RelionUS" /usr/local/bin/Run-RelionUS
 #
+# --- HTTPS ------------------------------------------------------------------
+# Off by default, and the single most important thing to turn on if this is
+# reachable from any machine but this one. Without it every byte -- the
+# password included -- crosses the network in plain text, and how well the
+# password is hashed on disk makes no difference, because an attacker on the
+# path reads the password itself rather than the hash.
+#   ./Run-RelionUS --make-cert           # generate a self-signed cert + key
+#   ./Run-RelionUS --tls                 # serve HTTPS with it
+#   ./Run-RelionUS --tls-cert C --tls-key K   # ...or your own certificate
+#   ./Run-RelionUS --hsts                # only with a real, CA-issued cert
+# A self-signed certificate encrypts exactly as well as a CA-issued one; what
+# it can't do is prove which server you reached, so the browser warns once.
+# --make-cert prints the certificate's SHA-256 fingerprint -- check it against
+# what the browser shows and that gap is closed too.
+#
 # --- Password protection ----------------------------------------------------
 # Off by default. Even with the localhost-only default bind, anyone else who
 # can already reach this machine's localhost (another user on a shared HPC
 # login node, for instance) can open jobs, run them, and delete run history
 # with no login at all -- and if you opt into --host 0.0.0.0, that's anyone
-# on your network. A password is a basic deterrent against that, not real
-# security: this app sets up no encryption, so the password (like everything
-# else it sends) crosses the network in plain text. See backend/auth.py's
-# module docstring for the full reasoning, including how to add real TLS if
-# you need it. Every time this script starts in an interactive terminal
-# without protection already turned on, it asks whether to set one up now;
-# skip or decline and it just asks again next time rather than staying quiet
-# forever, so use the flags below any time you'd rather set it up (or turn it
-# off) without being asked:
+# on your network. The password is stored as a salted scrypt hash and the
+# login endpoint locks out after repeated failures, so it stands up to
+# guessing -- but it protects nothing on the wire unless you also turn on
+# HTTPS above, or tunnel over SSH. Every time this script starts in an
+# interactive terminal without protection already turned on, it asks whether
+# to set one up now; skip or decline and it just asks again next time rather
+# than staying quiet forever, so use the flags below any time you'd rather
+# set it up (or turn it off) without being asked:
 #   ./Run-RelionUS --set-password        # set/change the password (prompts,
 #                                         #   hidden input, twice to confirm)
 #   ./Run-RelionUS --enable-auth         # require it from now on
@@ -63,10 +77,23 @@ run_auth_cli() { PYTHONPATH="$SCRIPT_DIR/backend" python3 "${AUTH_PY[@]}" "$@"; 
 
 HOST="127.0.0.1"
 PORT="8420"
+TLS_CERT=""
+TLS_KEY=""
+WANT_TLS=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --host) [[ $# -ge 2 ]] || { echo "--host needs a value" >&2; exit 1; }; HOST="$2"; shift 2 ;;
     --port) [[ $# -ge 2 ]] || { echo "--port needs a value" >&2; exit 1; }; PORT="$2"; shift 2 ;;
+    --tls) WANT_TLS=1; shift ;;
+    --tls-cert) [[ $# -ge 2 ]] || { echo "--tls-cert needs a value" >&2; exit 1; }; TLS_CERT="$2"; WANT_TLS=1; shift 2 ;;
+    --tls-key) [[ $# -ge 2 ]] || { echo "--tls-key needs a value" >&2; exit 1; }; TLS_KEY="$2"; WANT_TLS=1; shift 2 ;;
+    --make-cert)
+      # Optional hostname argument, but only if the next word isn't another
+      # flag -- so `--make-cert` alone works and defaults to this host's FQDN.
+      if [[ $# -ge 2 && "$2" != -* ]]; then run_auth_cli make-cert "$2"; else run_auth_cli make-cert; fi
+      exit $?
+      ;;
+    --hsts) export RELION_US_HSTS=1; shift ;;
     --set-password) run_auth_cli set-password; exit $? ;;
     --enable-auth) run_auth_cli enable; exit $? ;;
     --disable-auth) run_auth_cli disable; exit $? ;;
@@ -74,8 +101,15 @@ while [[ $# -gt 0 ]]; do
     --auth) export RELION_US_FORCE_AUTH=1; shift ;;
     --no-auth) export RELION_US_FORCE_AUTH=0; shift ;;
     -h|--help)
-      echo "Usage: $0 [--host HOST] [--port PORT] [--auth|--no-auth]"
+      echo "Usage: $0 [--host HOST] [--port PORT] [--tls] [--auth|--no-auth]"
+      echo "       $0 --tls-cert FILE --tls-key FILE   # your own certificate"
+      echo "       $0 --make-cert [hostname]           # generate a self-signed one"
       echo "       $0 --set-password|--enable-auth|--disable-auth|--auth-status"
+      echo
+      echo "  --tls    serve HTTPS. Without it everything, the password"
+      echo "           included, crosses the network in plain text."
+      echo "  --hsts   send Strict-Transport-Security (only with a real,"
+      echo "           CA-issued certificate -- see README)."
       exit 0
       ;;
     *)
@@ -84,6 +118,40 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+# Resolve which certificate to serve with. An explicit --tls-cert/--tls-key
+# pair wins; a bare --tls falls back to whatever --make-cert last recorded.
+SSL_ARGS=()
+if [[ "$WANT_TLS" == "1" ]]; then
+  if [[ -n "$TLS_CERT" || -n "$TLS_KEY" ]]; then
+    if [[ -z "$TLS_CERT" || -z "$TLS_KEY" ]]; then
+      echo "--tls-cert and --tls-key must be given together." >&2
+      exit 1
+    fi
+  else
+    # `tls-paths` prints cert then key, and prints nothing if either the
+    # config has no paths or the files they name are gone. The element count
+    # is the real check, not mapfile's exit status: mapfile reports on its
+    # own read, not on the process substitution's exit code, so a failed
+    # tls-paths still leaves mapfile "successful" with zero lines read.
+    # _paths is pre-declared because `set -u` treats an array that was never
+    # assigned as an unbound variable.
+    _paths=()
+    mapfile -t _paths < <(run_auth_cli tls-paths) || true
+    if [[ ${#_paths[@]} -ne 2 ]]; then
+      echo "No TLS certificate is set up yet." >&2
+      echo "Run './Run-RelionUS --make-cert' to generate one, or pass" >&2
+      echo "--tls-cert/--tls-key to use a certificate you already have." >&2
+      exit 1
+    fi
+    TLS_CERT="${_paths[0]}"
+    TLS_KEY="${_paths[1]}"
+  fi
+  for f in "$TLS_CERT" "$TLS_KEY"; do
+    [[ -r "$f" ]] || { echo "Cannot read TLS file: $f" >&2; exit 1; }
+  done
+  SSL_ARGS=(--ssl-certfile "$TLS_CERT" --ssl-keyfile "$TLS_KEY")
+fi
 
 # Asked every time protection isn't currently in effect for this run --
 # unlike the old one-time-ever prompt, declining doesn't silently opt you
@@ -122,4 +190,18 @@ fi
 # while the working directory stays the one the user launched from. Everything
 # else in the backend resolves its own paths from __file__, so nothing else
 # depends on the working directory being backend/.
-exec uvicorn --app-dir "$SCRIPT_DIR/backend" main:app --host "$HOST" --port "$PORT"
+SCHEME="http"; [[ ${#SSL_ARGS[@]} -gt 0 ]] && SCHEME="https"
+echo "RELION-US on ${SCHEME}://${HOST}:${PORT}/"
+if [[ "$SCHEME" == "http" && "$HOST" != "127.0.0.1" && "$HOST" != "localhost" ]]; then
+  # Bound to something other than loopback with no TLS: every password and
+  # every byte of job data is readable by anything on the path. Worth saying
+  # out loud rather than only in the README.
+  echo "WARNING: serving plain HTTP on a non-loopback address. The password" >&2
+  echo "and all traffic cross the network unencrypted. Use --tls (see" >&2
+  echo "--make-cert), or an SSH tunnel with the default --host 127.0.0.1." >&2
+fi
+# ${SSL_ARGS[@]+"${SSL_ARGS[@]}"} rather than a bare "${SSL_ARGS[@]}": under
+# `set -u`, bash before 4.4 treats an empty array expansion as unbound and
+# aborts, which would break every plain-HTTP launch on an older distro.
+exec uvicorn --app-dir "$SCRIPT_DIR/backend" main:app \
+  --host "$HOST" --port "$PORT" ${SSL_ARGS[@]+"${SSL_ARGS[@]}"}

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -11,13 +11,19 @@ who does open it up that way, or who shares a login node where other users
 can already reach localhost, gets no login at all otherwise. This module is
 a deliberately simple deterrent against that, not a security system:
 
-- No TLS is set up by this app, so the password (like everything else this
-  app sends) crosses the network in plain text. That is an accepted
-  trade-off, not an oversight -- ask before adding HTTPS here rather than
-  assuming it's missing by mistake. If you need real confidentiality, put
-  this behind a reverse proxy (nginx/Caddy) with TLS termination, or tunnel
-  over SSH (`ssh -L 8420:localhost:8420 <host>`, already how the README
-  suggests reaching a remote/HPC-hosted instance).
+- **TLS is supported and is what makes this real.** `Run-RelionUS --tls`
+  serves HTTPS directly (uvicorn's own SSL support), and `--make-cert`
+  generates a self-signed certificate if you don't have a real one. Without
+  TLS the password -- like everything else this app sends -- crosses the
+  network in plain text, and no amount of hashing at rest helps, because the
+  attacker reads the password itself off the wire. Run this over HTTPS, an
+  SSH tunnel, or a TLS-terminating reverse proxy any time it is reachable
+  from another machine.
+- A self-signed certificate encrypts exactly as well as a CA-issued one; what
+  it does not do is prove *which* server you reached, so the browser shows a
+  one-time warning and an active man-in-the-middle is not ruled out on a
+  hostile network. Pin the fingerprint `--make-cert` prints, or use a real
+  certificate, if that matters where you are.
 - One shared password, not per-user accounts. There is nothing here to
   audit "who did what" -- it only answers "did whoever's asking know the
   password".
@@ -31,11 +37,23 @@ a deliberately simple deterrent against that, not a security system:
 
 Storage: `project_manager.config_root() / "auth.json"` -- per-*user*, like
 the recent-projects cache, not per-project (the whole point is protecting
-the app before it even shows a project). Only a salted hash is stored, never
-the password itself, using stdlib `hashlib.pbkdf2_hmac` rather than pulling
-in bcrypt/argon2 as a new dependency -- iteration count is tuned to still be
-a real cost per guess, appropriate for "deter casual access to a lab
-instrument," not for defending a password worth targeting with a GPU.
+the app before it even shows a project). The file is created 0600 and never
+holds the password itself, only a salted hash.
+
+Hashing is stdlib `hashlib.scrypt` (RFC 7914) at n=2**15, r=8, p=1 -- the
+parameters RFC 7914 itself gives for interactive logins, ~32 MB and ~0.12 s
+per guess on a normal machine. scrypt is *memory*-hard, which is the
+property that makes bulk GPU/ASIC guessing expensive rather than merely
+slow, and it needs no new dependency (no bcrypt, no argon2). Hashes written
+by the older PBKDF2-HMAC-SHA256 scheme are still verified, and are silently
+re-hashed to scrypt on the next successful login (see needs_rehash /
+upgrade_hash_if_needed), so an existing install upgrades itself without
+anyone having to reset a password.
+
+Online guessing is bounded separately, by a lockout (see
+login_attempt_allowed): the KDF cost only prices *offline* guessing against
+a stolen auth.json, and 0.12 s per try is no obstacle at all to a script
+hammering the login endpoint.
 
 Sessions: a signed, stateless cookie (HMAC-SHA256 over an expiry timestamp,
 keyed by a random secret stored alongside the password hash) rather than a
@@ -51,6 +69,8 @@ import hmac
 import json
 import os
 import secrets
+import socket
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -63,9 +83,36 @@ COOKIE_NAME = "relion_us_session"
 SESSION_LIFETIME_SECONDS = 30 * 24 * 60 * 60  # 30 days -- a lab instrument
 # left logged in, not a banking site; re-entering a shared password every
 # day would just train people to leave the tab open forever instead.
-PBKDF2_ITERATIONS = 260_000  # ~OWASP's current floor for PBKDF2-SHA256
-MIN_PASSWORD_LENGTH = 4  # a deterrent floor, not a strength policy -- see
-# the module docstring for the threat model this is (and isn't) sized for.
+
+# --- Password hashing -------------------------------------------------------
+# scrypt (RFC 7914) at the RFC's own "interactive login" parameters. Memory-
+# hardness is the point: n=2**15/r=8 forces ~32 MB of working memory per
+# guess, which is what makes a GPU or ASIC farm expensive rather than just
+# a bit slower. OpenSSL refuses scrypt above a 32 MB default unless maxmem
+# is raised explicitly, so SCRYPT_MAXMEM is passed on every call -- without
+# it hashlib.scrypt raises "memory limit exceeded" at exactly these params.
+KDF_SCRYPT = "scrypt"
+KDF_PBKDF2 = "pbkdf2_sha256"
+CURRENT_KDF = KDF_SCRYPT
+SCRYPT_N = 2 ** 15
+SCRYPT_R = 8
+SCRYPT_P = 1
+SCRYPT_MAXMEM = 128 * SCRYPT_N * SCRYPT_R * 2   # 2x the requirement, headroom
+PBKDF2_ITERATIONS = 260_000  # legacy only -- still VERIFIED, never written
+MIN_PASSWORD_LENGTH = 8  # see _password_complaint for what else is refused
+
+# --- Online guessing --------------------------------------------------------
+# The KDF above prices OFFLINE guessing (someone who stole auth.json). It does
+# nothing against a script POSTing /api/auth/login in a loop, where 0.12s per
+# try is no obstacle. This lockout is that second, separate control.
+#
+# Kept in memory rather than persisted: a restart clears it, but restarting
+# the backend already requires a shell on this machine, and at that point the
+# attacker can read auth.json directly -- so persisting would add I/O on every
+# failed login to defend a case that is already lost.
+LOGIN_MAX_FAILURES = 5          # consecutive failures before the door shuts
+LOGIN_FAILURE_WINDOW = 300.0    # ...counted over this many seconds
+LOGIN_LOCKOUT_SECONDS = 300.0   # ...and then locked out for this long
 
 
 def config_path() -> Path:
@@ -73,7 +120,21 @@ def config_path() -> Path:
 
 
 def _default_config() -> dict[str, Any]:
-    return {"enabled": False, "password_hash": None, "salt": None, "session_secret": None}
+    return {
+        "enabled": False,
+        "password_hash": None,
+        "salt": None,
+        "session_secret": None,
+        # Which KDF produced password_hash. Absent in files written before
+        # scrypt existed here, which is exactly what makes them PBKDF2 --
+        # see load_config's own back-fill and needs_rehash.
+        "kdf": None,
+        # Paths to the TLS certificate/key --make-cert generated (or that
+        # --tls-cert/--tls-key were last pointed at), so `--tls` alone can
+        # find them on later runs. Not secret; the KEY FILE they name is.
+        "tls_cert": None,
+        "tls_key": None,
+    }
 
 
 def load_config() -> dict[str, Any]:
@@ -89,38 +150,116 @@ def load_config() -> dict[str, Any]:
         return _default_config()
     cfg = _default_config()
     cfg.update({k: data.get(k, v) for k, v in cfg.items()})
+    if cfg.get("password_hash") and not cfg.get("kdf"):
+        # Written before this module had more than one KDF, so it can only
+        # be the PBKDF2 one. Named explicitly here so every later check can
+        # just read cfg["kdf"] instead of re-deriving "no key means old".
+        cfg["kdf"] = KDF_PBKDF2
     return cfg
 
 
 def save_config(cfg: dict[str, Any]) -> None:
+    """Write auth.json 0600-from-creation, atomically.
+
+    Two things this deliberately does NOT do, both of which the previous
+    version did:
+
+    * `write_text()` then `chmod(0600)` creates the file at the umask's
+      permissions first and tightens them a moment later. On a shared login
+      node -- the exact machine this feature exists for -- that is a real
+      window in which another user can read the session-signing secret, and
+      winning it needs nothing cleverer than a loop. `os.open(..., 0o600)`
+      passes the mode to the syscall that creates the file, so the file never
+      exists at wider permissions.
+    * Writing in place truncates the real file before the new content lands,
+      so a crash mid-write leaves an empty or half-written auth.json --
+      which load_config would read as "no password set", silently turning
+      protection off. Writing a temp file in the same directory and
+      os.replace()-ing it is atomic on POSIX: readers see either the old
+      file or the new one, never a partial.
+    """
     p = config_path()
     p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(json.dumps(cfg, indent=2))
-    # Holds a password hash and a session-signing secret -- neither is the
-    # plaintext password, but there's no reason to leave it group/world
-    # readable on a shared machine either. Best-effort: not every filesystem
-    # (e.g. some network mounts) honours chmod, and that's not worth failing
-    # startup over.
+    tmp = p.with_name(p.name + f".tmp{os.getpid()}")
+    payload = json.dumps(cfg, indent=2)
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
-        os.chmod(p, 0o600)
-    except OSError:
-        pass
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(payload)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, p)
+    except BaseException:
+        # Never leave a stray .tmp holding the session secret behind.
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
-def _hash_password(password: str, salt: bytes) -> str:
-    return hashlib.pbkdf2_hmac(
-        "sha256", password.encode("utf-8"), salt, PBKDF2_ITERATIONS
-    ).hex()
+def _hash_password(password: str, salt: bytes, kdf: str = CURRENT_KDF) -> str:
+    """One password + salt -> hex digest, under the named KDF.
+
+    `kdf` is a parameter rather than always CURRENT_KDF because verifying an
+    existing hash has to use whichever function actually produced it; only
+    set_password/upgrade_hash_if_needed get to choose."""
+    pw = password.encode("utf-8")
+    if kdf == KDF_SCRYPT:
+        return hashlib.scrypt(
+            pw, salt=salt, n=SCRYPT_N, r=SCRYPT_R, p=SCRYPT_P,
+            maxmem=SCRYPT_MAXMEM, dklen=32,
+        ).hex()
+    if kdf == KDF_PBKDF2:
+        return hashlib.pbkdf2_hmac("sha256", pw, salt, PBKDF2_ITERATIONS).hex()
+    raise ValueError(f"unknown KDF: {kdf!r}")
+
+
+def _password_complaint(password: str) -> str | None:
+    """Why this password is refused, or None if it's acceptable.
+
+    Deliberately a floor, not a strength meter: length is the only property
+    that reliably predicts guessing cost, and composition rules ("must have a
+    digit and a symbol") mostly push people toward `Password1!` -- which is
+    in every cracking wordlist -- while doing nothing about length. So this
+    checks length, rejects the handful of passwords that are literally the
+    first thing anyone tries, and otherwise gets out of the way. Matches
+    NIST SP 800-63B's guidance (long minimum, screen against known-common
+    values, no composition rules, no forced rotation)."""
+    if len(password) < MIN_PASSWORD_LENGTH:
+        return f"Password must be at least {MIN_PASSWORD_LENGTH} characters."
+    if password.lower() in _COMMON_PASSWORDS:
+        return "That is one of the most commonly guessed passwords -- pick another."
+    if len(set(password)) < 3:
+        return "Password is too repetitive (fewer than 3 distinct characters)."
+    return None
+
+
+# Not a wordlist -- just the handful an unattended script tries in its first
+# second. A real wordlist belongs behind the lockout, not in this file.
+_COMMON_PASSWORDS = frozenset({
+    "password", "password1", "password123", "12345678", "123456789",
+    "1234567890", "qwertyui", "qwerty123", "letmein1", "iloveyou",
+    "admin123", "welcome1", "abc12345", "relion", "relionus", "relion-us",
+    "cryosparc", "changeme", "P@ssw0rd".lower(),
+})
 
 
 def set_password(password: str) -> None:
     """Stores a new password (as a salted hash) and rotates the session
     secret, so every session anywhere -- including one an attacker who'd
-    guessed the *old* password is holding -- is invalidated at once."""
+    guessed the *old* password is holding -- is invalidated at once.
+
+    Raises ValueError if the password is refused (see _password_complaint);
+    callers surface the message rather than storing something unusable."""
+    complaint = _password_complaint(password)
+    if complaint:
+        raise ValueError(complaint)
     cfg = load_config()
     salt = secrets.token_bytes(16)
     cfg["salt"] = salt.hex()
-    cfg["password_hash"] = _hash_password(password, salt)
+    cfg["kdf"] = CURRENT_KDF
+    cfg["password_hash"] = _hash_password(password, salt, CURRENT_KDF)
     cfg["session_secret"] = secrets.token_hex(32)
     save_config(cfg)
 
@@ -129,9 +268,51 @@ def verify_password(password: str, cfg: dict[str, Any] | None = None) -> bool:
     cfg = cfg if cfg is not None else load_config()
     if not cfg.get("password_hash") or not cfg.get("salt"):
         return False
-    salt = bytes.fromhex(cfg["salt"])
-    candidate = _hash_password(password, salt)
+    try:
+        salt = bytes.fromhex(cfg["salt"])
+        candidate = _hash_password(password, salt, cfg.get("kdf") or KDF_PBKDF2)
+    except ValueError:
+        # Corrupt salt, or a kdf name this build doesn't know (a config
+        # written by a NEWER RELION-US). Refusing the login is the only safe
+        # answer -- never fall through to "no password set".
+        return False
     return hmac.compare_digest(candidate, cfg["password_hash"])
+
+
+def needs_rehash(cfg: dict[str, Any] | None = None) -> bool:
+    """Whether the stored hash was made by an older KDF than the current one."""
+    cfg = cfg if cfg is not None else load_config()
+    return bool(cfg.get("password_hash")) and cfg.get("kdf") != CURRENT_KDF
+
+
+def upgrade_hash_if_needed(password: str, cfg: dict[str, Any] | None = None) -> bool:
+    """Re-hash an old PBKDF2 password under scrypt, in place.
+
+    Called only from the login path, with a password that has JUST verified
+    -- which is the one moment the plaintext is available to re-hash with,
+    and so the only way to migrate without making everyone reset. Returns
+    whether anything was written. Deliberately does not rotate the session
+    secret the way set_password does: the password itself hasn't changed, so
+    logging every device out would be a confusing side effect of an upgrade
+    nobody asked for.
+
+    Best-effort: a read-only config directory means the next login just tries
+    again, which is strictly better than failing a login that was correct."""
+    cfg = cfg if cfg is not None else load_config()
+    if not needs_rehash(cfg):
+        return False
+    fresh = load_config()          # re-read: this runs after a slow KDF
+    if not needs_rehash(fresh) or not verify_password(password, fresh):
+        return False               # changed underneath us; leave it alone
+    salt = secrets.token_bytes(16)
+    fresh["salt"] = salt.hex()
+    fresh["kdf"] = CURRENT_KDF
+    fresh["password_hash"] = _hash_password(password, salt, CURRENT_KDF)
+    try:
+        save_config(fresh)
+    except OSError:
+        return False
+    return True
 
 
 def is_enabled(cfg: dict[str, Any] | None = None) -> bool:
@@ -149,6 +330,170 @@ def is_enabled(cfg: dict[str, Any] | None = None) -> bool:
             return False
         return has_password
     return bool(cfg.get("enabled")) and has_password
+
+
+# --- Online guessing: lockout ----------------------------------------------
+# See the LOGIN_* constants for why this exists alongside the KDF cost.
+
+_failed_logins: dict[str, list[float]] = {}
+
+
+def _prune(times: list[float], now: float) -> list[float]:
+    return [t for t in times if now - t < LOGIN_FAILURE_WINDOW]
+
+
+def login_attempt_allowed(key: str, now: float | None = None) -> tuple[bool, int]:
+    """(allowed, seconds_to_wait) for the next login attempt from `key`.
+
+    `key` is the client's address; the caller decides what that means. A
+    second, fixed "global" key is checked alongside it by
+    record_failed_login, so someone rotating source addresses still trips a
+    limit -- per-address alone would be bypassed by exactly that.
+
+    Read-only: call record_failed_login on an actual failure.
+    """
+    now = time.time() if now is None else now
+    for bucket in (key, _GLOBAL_KEY):
+        times = _prune(_failed_logins.get(bucket, []), now)
+        _failed_logins[bucket] = times
+        if len(times) >= _limit_for(bucket):
+            wait = int(LOGIN_LOCKOUT_SECONDS - (now - max(times))) + 1
+            if wait > 0:
+                return False, wait
+            # Lockout elapsed -- forget the failures rather than making the
+            # next single mistake re-lock instantly.
+            _failed_logins[bucket] = []
+    return True, 0
+
+
+_GLOBAL_KEY = "*"
+
+
+def _limit_for(bucket: str) -> int:
+    # The global bucket is deliberately looser than a single address's: it is
+    # a backstop against address rotation, and setting it equal would let one
+    # clumsy user lock out the whole instance.
+    return LOGIN_MAX_FAILURES * 4 if bucket == _GLOBAL_KEY else LOGIN_MAX_FAILURES
+
+
+def record_failed_login(key: str, now: float | None = None) -> None:
+    now = time.time() if now is None else now
+    for bucket in (key, _GLOBAL_KEY):
+        _failed_logins[bucket] = _prune(_failed_logins.get(bucket, []), now) + [now]
+    # Bound memory: without this, one address per request grows this dict
+    # forever. Anything already outside the window is dead weight.
+    if len(_failed_logins) > 4096:
+        for k in [k for k, v in _failed_logins.items() if not v and k != _GLOBAL_KEY]:
+            _failed_logins.pop(k, None)
+
+
+def clear_failed_logins(key: str) -> None:
+    """A correct password clears that address's failures -- but NOT the global
+    bucket, which would otherwise let an attacker who knows any one valid
+    login reset the backstop for everyone."""
+    _failed_logins.pop(key, None)
+
+
+def reset_login_throttle() -> None:
+    """Test hook -- module state is process-global, so a test that fills the
+    buckets would otherwise leak into whatever runs next."""
+    _failed_logins.clear()
+
+
+# --- TLS --------------------------------------------------------------------
+
+def tls_paths(cfg: dict[str, Any] | None = None) -> tuple[str | None, str | None]:
+    """The stored (cert, key) paths, or (None, None). Existence is checked by
+    the caller at start time, not here -- a path recorded months ago can be
+    gone, and the CLI wants to say so rather than silently serving plain
+    HTTP."""
+    cfg = cfg if cfg is not None else load_config()
+    return cfg.get("tls_cert"), cfg.get("tls_key")
+
+
+def set_tls_paths(cert: str | None, key: str | None) -> None:
+    cfg = load_config()
+    cfg["tls_cert"] = str(cert) if cert else None
+    cfg["tls_key"] = str(key) if key else None
+    save_config(cfg)
+
+
+def default_cert_paths() -> tuple[Path, Path]:
+    root = project_manager.config_root()
+    return root / "tls_cert.pem", root / "tls_key.pem"
+
+
+def generate_self_signed_cert(hostname: str, days: int = 825) -> tuple[Path, Path, str]:
+    """Generate a self-signed cert+key with `openssl`, returning
+    (cert, key, sha256_fingerprint).
+
+    Shells out to openssl rather than adding `cryptography` to
+    requirements.txt: openssl is already present anywhere RELION is (RELION
+    links it), and this app's whole install story is "no more dependencies
+    than necessary". Raises RuntimeError with openssl's own message if it
+    isn't there or fails.
+
+    825 days is the CA/Browser Forum's maximum for a publicly-trusted leaf;
+    matching it here means a browser that enforces that ceiling on ALL certs
+    (Safari does, for anything issued after 2019) won't reject this one for
+    lasting too long.
+
+    The SAN covers `hostname` plus localhost/127.0.0.1/::1, because the
+    normal way to reach this app is an SSH tunnel to localhost even when the
+    certificate names the real host. A cert without a matching SAN entry is
+    rejected outright by every current browser -- CN alone has not been
+    accepted for years.
+    """
+    cert_path, key_path = default_cert_paths()
+    cert_path.parent.mkdir(parents=True, exist_ok=True)
+    san = f"DNS:{hostname},DNS:localhost,IP:127.0.0.1,IP:::1"
+    cmd = [
+        "openssl", "req", "-x509", "-newkey", "rsa:4096", "-nodes",
+        "-keyout", str(key_path), "-out", str(cert_path),
+        "-days", str(days), "-subj", f"/CN={hostname}",
+        "-addext", f"subjectAltName={san}",
+        "-addext", "basicConstraints=critical,CA:FALSE",
+        "-addext", "keyUsage=critical,digitalSignature,keyEncipherment",
+        "-addext", "extendedKeyUsage=serverAuth",
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    except FileNotFoundError:
+        raise RuntimeError(
+            "openssl is not on PATH, so a certificate can't be generated here. "
+            "Install it, or point --tls-cert/--tls-key at a certificate you "
+            "already have."
+        ) from None
+    except subprocess.TimeoutExpired:
+        raise RuntimeError("openssl did not finish within 120s.") from None
+    if proc.returncode != 0:
+        raise RuntimeError(f"openssl failed: {(proc.stderr or '').strip()}")
+    # The private key is the whole secret here -- openssl writes it at the
+    # umask, which on most systems is world-readable.
+    try:
+        os.chmod(key_path, 0o600)
+    except OSError:
+        pass
+    return cert_path, key_path, cert_fingerprint(cert_path)
+
+
+def cert_fingerprint(cert_path: Path) -> str:
+    """SHA-256 fingerprint of a certificate, as openssl prints it.
+
+    This is what makes a self-signed cert genuinely checkable: compare what
+    the browser shows against this and a man-in-the-middle is ruled out,
+    which is the one guarantee a CA would otherwise be providing."""
+    try:
+        proc = subprocess.run(
+            ["openssl", "x509", "-in", str(cert_path), "-noout",
+             "-fingerprint", "-sha256"],
+            capture_output=True, text=True, timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return "(could not read fingerprint)"
+    if proc.returncode != 0:
+        return "(could not read fingerprint)"
+    return (proc.stdout or "").strip().split("=", 1)[-1].strip()
 
 
 def enable() -> None:
@@ -214,8 +559,9 @@ def _prompt_new_password() -> str | None:
     try:
         while True:
             pw1 = getpass.getpass("New RELION-US password: ")
-            if len(pw1) < MIN_PASSWORD_LENGTH:
-                print(f"Password must be at least {MIN_PASSWORD_LENGTH} characters.")
+            complaint = _password_complaint(pw1)
+            if complaint:
+                print(complaint)
                 continue
             pw2 = getpass.getpass("Confirm: ")
             if pw1 != pw2:
@@ -232,7 +578,13 @@ def cli_set_password() -> int:
     if pw is None:
         print("Cancelled -- password unchanged.")
         return 1
-    set_password(pw)
+    try:
+        set_password(pw)
+    except ValueError as exc:
+        # _prompt_new_password already applied the same rule, so reaching
+        # here means the two disagree -- report rather than crash.
+        print(str(exc))
+        return 1
     cfg = load_config()
     print(f"Password set. ({config_path()})")
     if not cfg.get("enabled"):
@@ -268,7 +620,61 @@ def cli_status() -> int:
     has_pw = bool(cfg.get("password_hash"))
     print(f"Config file:  {config_path()}")
     print(f"Password set: {'yes' if has_pw else 'no'}")
+    if has_pw:
+        kdf = cfg.get("kdf") or KDF_PBKDF2
+        note = "" if kdf == CURRENT_KDF else "  (upgrades to scrypt on next login)"
+        print(f"Hashed with:  {kdf}{note}")
     print(f"Protection:   {'ON' if is_enabled(cfg) else 'OFF'}")
+    cert, key = tls_paths(cfg)
+    if cert and key:
+        missing = [p for p in (cert, key) if not Path(p).exists()]
+        if missing:
+            print(f"TLS:          configured, but MISSING: {', '.join(missing)}")
+        else:
+            print(f"TLS:          {cert}")
+            print(f"  key:        {key}")
+            print(f"  SHA-256:    {cert_fingerprint(Path(cert))}")
+    else:
+        print("TLS:          not set up -- run `Run-RelionUS --make-cert` "
+              "(traffic is plain text without it)")
+    return 0
+
+
+def cli_make_cert(hostname: str | None = None) -> int:
+    host = hostname or socket.getfqdn() or "localhost"
+    print(f"Generating a self-signed certificate for {host} ...")
+    try:
+        cert, key, fingerprint = generate_self_signed_cert(host)
+    except RuntimeError as exc:
+        print(str(exc))
+        return 1
+    set_tls_paths(str(cert), str(key))
+    print(f"  certificate: {cert}")
+    print(f"  private key: {key}  (0600)")
+    print(f"  SHA-256:     {fingerprint}")
+    print()
+    print("Start with HTTPS:  ./Run-RelionUS --tls")
+    print()
+    print("Your browser will warn once that this certificate isn't from a")
+    print("recognized authority -- that is expected, and it does NOT mean the")
+    print("connection is unencrypted. Check the fingerprint it shows matches")
+    print("the SHA-256 above, then accept it. To avoid the warning entirely,")
+    print("use a certificate from your institution or Let's Encrypt with")
+    print("--tls-cert/--tls-key instead.")
+    return 0
+
+
+def cli_tls_paths() -> int:
+    """Silent except for the paths -- Run-RelionUS reads these to build its
+    uvicorn command. Exit 1 (printing nothing) when TLS isn't configured, so
+    the caller can branch on the exit code alone."""
+    cert, key = tls_paths()
+    if not cert or not key:
+        return 1
+    if not Path(cert).exists() or not Path(key).exists():
+        return 1
+    print(cert)
+    print(key)
     return 0
 
 
@@ -288,10 +694,19 @@ def main(argv: list[str]) -> int:
         "enable": cli_enable,
         "disable": cli_disable,
         "is-enabled": cli_is_enabled,
+        "tls-paths": cli_tls_paths,
     }
+    # make-cert is the one verb taking an argument (the hostname to put in
+    # the certificate), so it's matched before the no-argument table.
+    if argv and argv[0] == "make-cert":
+        if len(argv) > 2:
+            print("Usage: make-cert [hostname]")
+            return 2
+        return cli_make_cert(argv[1] if len(argv) == 2 else None)
     if len(argv) != 1 or argv[0] not in commands:
         print(f"Usage: {Path(sys.argv[0]).name} "
-              "{status|set-password|enable|disable|is-enabled}")
+              "{status|set-password|enable|disable|is-enabled|tls-paths|"
+              "make-cert [hostname]}")
         return 2
     return commands[argv[0]]()
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -233,6 +233,57 @@ project_manager.remember_project(PROJECT_DIR)
 _AUTH_PUBLIC_PATHS = {"/login.html", "/api/auth/status", "/api/auth/login", "/favicon.ico"}
 
 
+def _is_secure_request(request: Request) -> bool:
+    """Whether this request actually arrived over TLS.
+
+    Checks X-Forwarded-Proto as well as the URL scheme because the supported
+    "real certificate" deployment is a TLS-terminating reverse proxy, where
+    the app itself only ever sees plain HTTP and request.url.scheme would say
+    "http" on a connection the browser made over HTTPS. Getting that wrong
+    means never setting Secure on the cookie in exactly the deployment that
+    most deserves it.
+
+    Trusting a client-settable header is only safe behind a proxy that
+    overwrites it, which is why this is used ONLY to *add* protections
+    (Secure, HSTS) and never to grant access: a forged header can make a
+    plain-HTTP client's own cookie stricter than necessary, which breaks
+    nothing an attacker benefits from.
+    """
+    if request.url.scheme == "https":
+        return True
+    return request.headers.get("x-forwarded-proto", "").split(",")[0].strip() == "https"
+
+
+# Cheap, always-on response headers. None of these replace TLS; they close
+# the ordinary browser-side gaps that remain once TLS is in place.
+_SECURITY_HEADERS = {
+    # This app renders server-side file paths and RELION's own output; stop
+    # the browser from second-guessing declared content types.
+    "X-Content-Type-Options": "nosniff",
+    # Nothing here is meant to be embedded elsewhere, and framing it is the
+    # setup for clickjacking a Run button.
+    "X-Frame-Options": "DENY",
+    # Don't leak project paths in the Referer when a link goes off-site.
+    "Referrer-Policy": "same-origin",
+}
+
+
+@app.middleware("http")
+async def security_headers(request: Request, call_next):
+    response = await call_next(request)
+    for header, value in _SECURITY_HEADERS.items():
+        response.headers.setdefault(header, value)
+    # HSTS only over a connection that is ALREADY TLS, and only when opted
+    # into: it tells the browser to refuse plain HTTP to this host for the
+    # given period, which is exactly right in front of a real certificate and
+    # a self-inflicted lockout if you are still evaluating a self-signed one
+    # and want to drop back to http. RELION_US_HSTS=1 turns it on.
+    if os.environ.get("RELION_US_HSTS") == "1" and _is_secure_request(request):
+        response.headers.setdefault(
+            "Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+    return response
+
+
 @app.middleware("http")
 async def auth_gate(request: Request, call_next):
     cfg = auth.load_config()
@@ -256,14 +307,36 @@ def auth_status():
 
 
 @app.post("/api/auth/login")
-async def auth_login(req: LoginRequest):
+async def auth_login(req: LoginRequest, request: Request):
+    # Lock out repeated failures BEFORE spending a KDF on the guess: scrypt
+    # costs ~0.12s and ~32MB, so an unthrottled login endpoint is both a
+    # guessing oracle and a cheap way to exhaust this machine's memory. The
+    # old fixed 0.5s sleep did neither job -- it rate-limited one connection
+    # while a script with 50 in parallel was unaffected.
+    client = request.client.host if request.client else "unknown"
+    allowed, retry_after = auth.login_attempt_allowed(client)
+    if not allowed:
+        raise HTTPException(
+            status_code=429,
+            detail=f"Too many failed attempts. Try again in {retry_after}s.",
+            headers={"Retry-After": str(retry_after)},
+        )
     cfg = auth.load_config()
-    if not auth.verify_password(req.password, cfg):
-        # A small fixed delay on a wrong guess -- cheap insurance against a
-        # trivial guessing script, in keeping with this being a deterrent
-        # rather than a hardened login (see auth.py's module docstring).
-        await asyncio.sleep(0.5)
+    # Off the event loop: scrypt holds the GIL for its whole run, so hashing
+    # inline would stall every other request and websocket in the app for
+    # ~0.12s per login attempt.
+    ok = await asyncio.to_thread(auth.verify_password, req.password, cfg)
+    if not ok:
+        auth.record_failed_login(client)
         raise HTTPException(status_code=401, detail="Incorrect password")
+    auth.clear_failed_logins(client)
+    # A correct password is the only moment the plaintext exists to re-hash
+    # with, so an install still on the old PBKDF2 hash migrates here -- see
+    # auth.upgrade_hash_if_needed. Best-effort and off the event loop for
+    # the same reason as above.
+    if auth.needs_rehash(cfg):
+        await asyncio.to_thread(auth.upgrade_hash_if_needed, req.password, cfg)
+        cfg = auth.load_config()
     response = JSONResponse({"ok": True})
     response.set_cookie(
         auth.COOKIE_NAME,
@@ -271,14 +344,29 @@ async def auth_login(req: LoginRequest):
         max_age=auth.SESSION_LIFETIME_SECONDS,
         httponly=True,
         samesite="lax",
+        # Set only over TLS: a Secure cookie is never sent over plain HTTP,
+        # so hard-coding it would silently break every plain-HTTP install
+        # (the login would appear to succeed and every next request would
+        # 401). Over TLS it is what stops the session token from leaking if
+        # anything ever downgrades this host to http.
+        secure=_is_secure_request(request),
     )
     return response
 
 
 @app.post("/api/auth/logout")
-def auth_logout():
+def auth_logout(request: Request):
     response = JSONResponse({"ok": True})
-    response.delete_cookie(auth.COOKIE_NAME)
+    # delete_cookie must repeat the attributes the cookie was SET with:
+    # a browser treats path/samesite/secure as part of the cookie's identity,
+    # so a bare delete leaves an HTTPS-set Secure cookie in place and the
+    # user stays logged in after clicking Log out.
+    response.delete_cookie(
+        auth.COOKIE_NAME,
+        httponly=True,
+        samesite="lax",
+        secure=_is_secure_request(request),
+    )
     return response
 
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -88,6 +88,148 @@ def test_same_password_gets_a_different_hash_each_time(auth_home):
     assert hash1 != hash2
 
 
+def test_password_is_hashed_with_scrypt_not_the_legacy_pbkdf2(auth_home):
+    auth.set_password("correct horse battery staple")
+    assert auth.load_config()["kdf"] == auth.KDF_SCRYPT
+
+
+def test_short_and_common_passwords_are_refused(auth_home):
+    for bad in ("short", "password123", "aaaaaaaaaa"):
+        with pytest.raises(ValueError):
+            auth.set_password(bad)
+    # ...and nothing was stored by the refused attempts.
+    assert auth.load_config()["password_hash"] is None
+
+
+# --- PBKDF2 -> scrypt migration -------------------------------------------
+# An install predating scrypt has a PBKDF2 hash and no "kdf" key at all.
+# It has to keep working, and upgrade itself, without anyone resetting a
+# password -- otherwise raising the KDF silently locks existing users out.
+
+def _write_legacy_pbkdf2_config(password: str) -> dict:
+    import json
+    import secrets
+    salt = secrets.token_bytes(16)
+    legacy = {
+        "enabled": True,
+        "password_hash": auth._hash_password(password, salt, auth.KDF_PBKDF2),
+        "salt": salt.hex(),
+        "session_secret": secrets.token_hex(32),
+    }
+    auth.config_path().parent.mkdir(parents=True, exist_ok=True)
+    auth.config_path().write_text(json.dumps(legacy))
+    return legacy
+
+
+def test_legacy_pbkdf2_config_is_identified_as_such(auth_home):
+    _write_legacy_pbkdf2_config("legacy-password")
+    assert auth.load_config()["kdf"] == auth.KDF_PBKDF2
+    assert auth.needs_rehash() is True
+
+
+def test_legacy_pbkdf2_password_still_verifies(auth_home):
+    _write_legacy_pbkdf2_config("legacy-password")
+    assert auth.verify_password("legacy-password") is True
+    assert auth.verify_password("wrong-password") is False
+
+
+def test_successful_login_upgrades_a_legacy_hash_to_scrypt(auth_home):
+    legacy = _write_legacy_pbkdf2_config("legacy-password")
+    assert auth.upgrade_hash_if_needed("legacy-password") is True
+    after = auth.load_config()
+    assert after["kdf"] == auth.KDF_SCRYPT
+    assert after["password_hash"] != legacy["password_hash"]
+    assert auth.needs_rehash(after) is False
+    # The same password must still work afterwards -- an upgrade that
+    # invalidated the password would be worse than no upgrade.
+    assert auth.verify_password("legacy-password", after) is True
+
+
+def test_upgrade_keeps_the_session_secret_so_nobody_is_logged_out(auth_home):
+    legacy = _write_legacy_pbkdf2_config("legacy-password")
+    auth.upgrade_hash_if_needed("legacy-password")
+    assert auth.load_config()["session_secret"] == legacy["session_secret"]
+
+
+def test_upgrade_is_a_no_op_for_a_wrong_password_or_current_hash(auth_home):
+    _write_legacy_pbkdf2_config("legacy-password")
+    assert auth.upgrade_hash_if_needed("not-the-password") is False
+    assert auth.load_config()["kdf"] == auth.KDF_PBKDF2
+    auth.set_password("already-scrypt-password")
+    assert auth.upgrade_hash_if_needed("already-scrypt-password") is False
+
+
+def test_unknown_kdf_refuses_the_login_rather_than_falling_open(auth_home):
+    import json
+    auth.set_password("some-good-password")
+    cfg = auth.load_config()
+    cfg["kdf"] = "kdf-from-a-newer-version"
+    auth.config_path().write_text(json.dumps(cfg))
+    assert auth.verify_password("some-good-password") is False
+
+
+# --- login lockout ---------------------------------------------------------
+
+def test_lockout_opens_after_repeated_failures_and_blocks_further_attempts():
+    auth.reset_login_throttle()
+    try:
+        for _ in range(auth.LOGIN_MAX_FAILURES):
+            assert auth.login_attempt_allowed("10.0.0.1")[0] is True
+            auth.record_failed_login("10.0.0.1")
+        allowed, retry_after = auth.login_attempt_allowed("10.0.0.1")
+        assert allowed is False
+        assert 0 < retry_after <= auth.LOGIN_LOCKOUT_SECONDS + 1
+    finally:
+        auth.reset_login_throttle()
+
+
+def test_lockout_is_per_address_so_one_user_cannot_lock_out_another():
+    auth.reset_login_throttle()
+    try:
+        for _ in range(auth.LOGIN_MAX_FAILURES):
+            auth.record_failed_login("10.0.0.1")
+        assert auth.login_attempt_allowed("10.0.0.1")[0] is False
+        assert auth.login_attempt_allowed("10.0.0.2")[0] is True
+    finally:
+        auth.reset_login_throttle()
+
+
+def test_a_global_backstop_stops_address_rotation_from_bypassing_the_lockout():
+    auth.reset_login_throttle()
+    try:
+        # A fresh address every time never trips the per-address limit, so
+        # without the global bucket this loop would be an unlimited oracle.
+        for i in range(auth.LOGIN_MAX_FAILURES * 4):
+            auth.record_failed_login(f"10.0.1.{i}")
+        assert auth.login_attempt_allowed("10.0.99.99")[0] is False
+    finally:
+        auth.reset_login_throttle()
+
+
+def test_a_correct_password_clears_that_addresss_failures():
+    auth.reset_login_throttle()
+    try:
+        for _ in range(auth.LOGIN_MAX_FAILURES - 1):
+            auth.record_failed_login("10.0.0.1")
+        auth.clear_failed_logins("10.0.0.1")
+        for _ in range(auth.LOGIN_MAX_FAILURES - 1):
+            auth.record_failed_login("10.0.0.1")
+        assert auth.login_attempt_allowed("10.0.0.1")[0] is True
+    finally:
+        auth.reset_login_throttle()
+
+
+def test_failures_outside_the_window_do_not_count():
+    auth.reset_login_throttle()
+    try:
+        old = time.time() - auth.LOGIN_FAILURE_WINDOW - 1
+        for _ in range(auth.LOGIN_MAX_FAILURES):
+            auth.record_failed_login("10.0.0.1", now=old)
+        assert auth.login_attempt_allowed("10.0.0.1")[0] is True
+    finally:
+        auth.reset_login_throttle()
+
+
 # --- enable/disable -------------------------------------------------------
 
 def test_enabling_without_a_password_raises(auth_home):
@@ -96,37 +238,37 @@ def test_enabling_without_a_password_raises(auth_home):
 
 
 def test_enable_requires_a_password_then_is_enabled(auth_home):
-    auth.set_password("x123")
+    auth.set_password("test-password-x123")
     auth.enable()
     assert auth.is_enabled() is True
 
 
 def test_setting_a_password_does_not_itself_enable_it(auth_home):
-    auth.set_password("x123")
+    auth.set_password("test-password-x123")
     assert auth.is_enabled() is False
 
 
 def test_disable_keeps_the_password_hash(auth_home):
-    auth.set_password("x123")
+    auth.set_password("test-password-x123")
     auth.enable()
     auth.disable()
     cfg = auth.load_config()
     assert cfg["enabled"] is False
     assert cfg["password_hash"] is not None
-    assert auth.verify_password("x123", cfg) is True
+    assert auth.verify_password("test-password-x123", cfg) is True
 
 
 # --- RELION_US_FORCE_AUTH (Run-RelionUS --auth / --no-auth) ---------------
 
 def test_force_auth_0_disables_even_if_persisted_enabled(auth_home, monkeypatch):
-    auth.set_password("x123")
+    auth.set_password("test-password-x123")
     auth.enable()
     monkeypatch.setenv("RELION_US_FORCE_AUTH", "0")
     assert auth.is_enabled() is False
 
 
 def test_force_auth_1_enables_if_a_password_exists(auth_home, monkeypatch):
-    auth.set_password("x123")
+    auth.set_password("test-password-x123")
     # Deliberately not calling enable() -- the whole point is the override.
     monkeypatch.setenv("RELION_US_FORCE_AUTH", "1")
     assert auth.is_enabled() is True
@@ -143,27 +285,27 @@ def test_force_auth_1_is_a_no_op_without_a_password(auth_home, monkeypatch):
 # --- sessions ---------------------------------------------------------------
 
 def test_fresh_session_token_is_valid(auth_home):
-    auth.set_password("x123")
+    auth.set_password("test-password-x123")
     cfg = auth.load_config()
     token = auth.new_session_token(cfg)
     assert auth.session_is_valid(token, cfg) is True
 
 
 def test_no_token_is_invalid(auth_home):
-    auth.set_password("x123")
+    auth.set_password("test-password-x123")
     assert auth.session_is_valid(None) is False
     assert auth.session_is_valid("") is False
 
 
 def test_malformed_token_is_invalid(auth_home):
-    auth.set_password("x123")
+    auth.set_password("test-password-x123")
     cfg = auth.load_config()
     assert auth.session_is_valid("not.a.valid.token.shape.but.has.dots", cfg) is False
     assert auth.session_is_valid("nodothere", cfg) is False
 
 
 def test_tampered_token_is_invalid(auth_home):
-    auth.set_password("x123")
+    auth.set_password("test-password-x123")
     cfg = auth.load_config()
     token = auth.new_session_token(cfg)
     expiry, sig = token.split(".", 1)
@@ -172,7 +314,7 @@ def test_tampered_token_is_invalid(auth_home):
 
 
 def test_expired_token_is_invalid(auth_home):
-    auth.set_password("x123")
+    auth.set_password("test-password-x123")
     cfg = auth.load_config()
     expired_expiry = str(int(time.time()) - 10)
     sig = auth._sign(expired_expiry, cfg["session_secret"])
@@ -180,12 +322,12 @@ def test_expired_token_is_invalid(auth_home):
 
 
 def test_changing_password_invalidates_existing_sessions(auth_home):
-    auth.set_password("first")
+    auth.set_password("first-password")
     cfg1 = auth.load_config()
     token = auth.new_session_token(cfg1)
     assert auth.session_is_valid(token, auth.load_config()) is True
 
-    auth.set_password("second")
+    auth.set_password("second-password")
     cfg2 = auth.load_config()
     assert cfg2["session_secret"] != cfg1["session_secret"]
     assert auth.session_is_valid(token, cfg2) is False
@@ -233,7 +375,7 @@ def test_cli_enable_without_password_fails(auth_home, capsys):
 
 
 def test_cli_enable_then_disable(auth_home):
-    auth.set_password("x123")
+    auth.set_password("test-password-x123")
     assert auth.cli_enable() == 0
     assert auth.is_enabled() is True
     assert auth.cli_disable() == 0
@@ -243,7 +385,7 @@ def test_cli_enable_then_disable(auth_home):
 def test_cli_is_enabled_reflects_whether_protection_is_currently_on(auth_home):
     # No config at all yet -- Run-RelionUS's startup prompt should still ask.
     assert auth.cli_is_enabled() == 1
-    auth.set_password("x123")
+    auth.set_password("test-password-x123")
     # A password alone doesn't count as "enabled" -- still asks.
     assert auth.cli_is_enabled() == 1
     auth.enable()

--- a/backend/tests/test_custom_jobs.py
+++ b/backend/tests/test_custom_jobs.py
@@ -255,10 +255,13 @@ def test_stays_running_job_reaches_running_not_completed(synced_project):
             return await custom_jobs.run_manual_pick(project, values, job_dir)
         run = await manager.start_custom_job(
             "Manualpick", "Manual Picking", factory, field_values=values, stays_running=True)
-        for _ in range(200):
-            await asyncio.sleep(0.02)
-            if run.status != "pending":
-                break
+        # Await the task rather than polling for a status change:
+        # _run_custom sets "running" as its FIRST action, so a poll on
+        # `status != "pending"` returns while the task is still in flight.
+        # asyncio.run() then cancels it during loop teardown and
+        # _run_custom's CancelledError handler rewrites the status to
+        # "aborted" -- which is what made these tests fail ~25% of runs.
+        await run.task
         return run
 
     run = asyncio.run(go())
@@ -290,10 +293,13 @@ def test_done_button_finishes_a_stays_running_job(synced_project):
             return await custom_jobs.run_manual_pick(project, values, job_dir)
         run = await manager.start_custom_job(
             "Manualpick", "Manual Picking", factory, field_values=values, stays_running=True)
-        for _ in range(200):
-            await asyncio.sleep(0.02)
-            if run.status != "pending":
-                break
+        # Await the task rather than polling for a status change:
+        # _run_custom sets "running" as its FIRST action, so a poll on
+        # `status != "pending"` returns while the task is still in flight.
+        # asyncio.run() then cancels it during loop teardown and
+        # _run_custom's CancelledError handler rewrites the status to
+        # "aborted" -- which is what made these tests fail ~25% of runs.
+        await run.task
         assert run.status == "running"
         updated = await manager.set_status(run.run_id, "completed")
         return run, updated
@@ -324,10 +330,13 @@ def test_resume_run_returns_to_running_without_touching_picks(synced_project):
             return await custom_jobs.run_manual_pick(project, values, job_dir)
         run = await manager.start_custom_job(
             "Manualpick", "Manual Picking", factory, field_values=values, stays_running=True)
-        for _ in range(200):
-            await asyncio.sleep(0.02)
-            if run.status != "pending":
-                break
+        # Await the task rather than polling for a status change:
+        # _run_custom sets "running" as its FIRST action, so a poll on
+        # `status != "pending"` returns while the task is still in flight.
+        # asyncio.run() then cancels it during loop teardown and
+        # _run_custom's CancelledError handler rewrites the status to
+        # "aborted" -- which is what made these tests fail ~25% of runs.
+        await run.task
         import manual_pick
         manual_pick.save_spa_picks(project, Path(run.cwd), "a.mrc", [{"x": 1.0, "y": 2.0}])
         await manager.set_status(run.run_id, "completed")
@@ -359,10 +368,13 @@ def test_resume_run_rejects_a_currently_running_job(synced_project):
             return await custom_jobs.run_manual_pick(project, values, job_dir)
         run = await manager.start_custom_job(
             "Manualpick", "Manual Picking", factory, field_values=values, stays_running=True)
-        for _ in range(200):
-            await asyncio.sleep(0.02)
-            if run.status != "pending":
-                break
+        # Await the task rather than polling for a status change:
+        # _run_custom sets "running" as its FIRST action, so a poll on
+        # `status != "pending"` returns while the task is still in flight.
+        # asyncio.run() then cancels it during loop teardown and
+        # _run_custom's CancelledError handler rewrites the status to
+        # "aborted" -- which is what made these tests fail ~25% of runs.
+        await run.task
         assert run.status == "running"
         with pytest.raises(ValueError, match="resume"):
             await manager.resume_run(run.run_id)
@@ -386,10 +398,13 @@ def test_overwrite_clears_prior_picks_and_resumes_running(synced_project):
             return await custom_jobs.run_manual_pick(project, values, job_dir)
         run = await manager.start_custom_job(
             "Manualpick", "Manual Picking", factory, field_values=values, stays_running=True)
-        for _ in range(200):
-            await asyncio.sleep(0.02)
-            if run.status != "pending":
-                break
+        # Await the task rather than polling for a status change:
+        # _run_custom sets "running" as its FIRST action, so a poll on
+        # `status != "pending"` returns while the task is still in flight.
+        # asyncio.run() then cancels it during loop teardown and
+        # _run_custom's CancelledError handler rewrites the status to
+        # "aborted" -- which is what made these tests fail ~25% of runs.
+        await run.task
         import manual_pick
         manual_pick.save_spa_picks(project, Path(run.cwd), "a.mrc", [{"x": 1.0, "y": 2.0}])
         await manager.set_status(run.run_id, "completed")
@@ -398,10 +413,13 @@ def test_overwrite_clears_prior_picks_and_resumes_running(synced_project):
             "Manualpick", "Manual Picking", factory, field_values=values,
             overwrite_run_id=run.run_id, stays_running=True,
         )
-        for _ in range(200):
-            await asyncio.sleep(0.02)
-            if overwritten.status != "pending":
-                break
+        # Await the task rather than polling for a status change:
+        # _run_custom sets "running" as its FIRST action, so a poll on
+        # `status != "pending"` returns while the task is still in flight.
+        # asyncio.run() then cancels it during loop teardown and
+        # _run_custom's CancelledError handler rewrites the status to
+        # "aborted" -- which is what made these tests fail ~25% of runs.
+        await overwritten.task
         return run, overwritten
 
     run, overwritten = asyncio.run(go())
@@ -474,10 +492,13 @@ def test_excludetiltimages_job_registers_in_relions_pipeline_and_stays_running(s
             return await custom_jobs.run_exclude_tilt_images(project, values, job_dir)
         run = await manager.start_custom_job(
             "TomoExcludeTiltImages", "Exclude Tilt Images", factory, field_values=values, stays_running=True)
-        for _ in range(200):
-            await asyncio.sleep(0.02)
-            if run.status != "pending":
-                break
+        # Await the task rather than polling for a status change:
+        # _run_custom sets "running" as its FIRST action, so a poll on
+        # `status != "pending"` returns while the task is still in flight.
+        # asyncio.run() then cancels it during loop teardown and
+        # _run_custom's CancelledError handler rewrites the status to
+        # "aborted" -- which is what made these tests fail ~25% of runs.
+        await run.task
         return run
 
     run = asyncio.run(go())
@@ -507,10 +528,13 @@ def test_excludetiltimages_done_then_continue_preserves_saved_exclusions(synced_
             return await custom_jobs.run_exclude_tilt_images(project, values, job_dir)
         run = await manager.start_custom_job(
             "TomoExcludeTiltImages", "Exclude Tilt Images", factory, field_values=values, stays_running=True)
-        for _ in range(200):
-            await asyncio.sleep(0.02)
-            if run.status != "pending":
-                break
+        # Await the task rather than polling for a status change:
+        # _run_custom sets "running" as its FIRST action, so a poll on
+        # `status != "pending"` returns while the task is still in flight.
+        # asyncio.run() then cancels it during loop teardown and
+        # _run_custom's CancelledError handler rewrites the status to
+        # "aborted" -- which is what made these tests fail ~25% of runs.
+        await run.task
         import exclude_tilts
         exclude_tilts.save_tilt_series_exclusions(project, Path(run.cwd), in_tiltseries, "TS_01", ["a.mrc"])
         await manager.set_status(run.run_id, "completed")
@@ -546,10 +570,13 @@ def test_excludetiltimages_overwrite_clears_prior_exclusions(synced_project):
             return await custom_jobs.run_exclude_tilt_images(project, values, job_dir)
         run = await manager.start_custom_job(
             "TomoExcludeTiltImages", "Exclude Tilt Images", factory, field_values=values, stays_running=True)
-        for _ in range(200):
-            await asyncio.sleep(0.02)
-            if run.status != "pending":
-                break
+        # Await the task rather than polling for a status change:
+        # _run_custom sets "running" as its FIRST action, so a poll on
+        # `status != "pending"` returns while the task is still in flight.
+        # asyncio.run() then cancels it during loop teardown and
+        # _run_custom's CancelledError handler rewrites the status to
+        # "aborted" -- which is what made these tests fail ~25% of runs.
+        await run.task
         import exclude_tilts
         exclude_tilts.save_tilt_series_exclusions(project, Path(run.cwd), in_tiltseries, "TS_01", ["a.mrc"])
         await manager.set_status(run.run_id, "completed")
@@ -558,10 +585,13 @@ def test_excludetiltimages_overwrite_clears_prior_exclusions(synced_project):
             "TomoExcludeTiltImages", "Exclude Tilt Images", factory, field_values=values,
             overwrite_run_id=run.run_id, stays_running=True,
         )
-        for _ in range(200):
-            await asyncio.sleep(0.02)
-            if overwritten.status != "pending":
-                break
+        # Await the task rather than polling for a status change:
+        # _run_custom sets "running" as its FIRST action, so a poll on
+        # `status != "pending"` returns while the task is still in flight.
+        # asyncio.run() then cancels it during loop teardown and
+        # _run_custom's CancelledError handler rewrites the status to
+        # "aborted" -- which is what made these tests fail ~25% of runs.
+        await overwritten.task
         return run, overwritten
 
     run, overwritten = asyncio.run(go())
@@ -590,20 +620,26 @@ def test_overwrite_works_directly_on_a_still_running_picking_session(synced_proj
             return await custom_jobs.run_manual_pick(project, values, job_dir)
         run = await manager.start_custom_job(
             "Manualpick", "Manual Picking", factory, field_values=values, stays_running=True)
-        for _ in range(200):
-            await asyncio.sleep(0.02)
-            if run.status != "pending":
-                break
+        # Await the task rather than polling for a status change:
+        # _run_custom sets "running" as its FIRST action, so a poll on
+        # `status != "pending"` returns while the task is still in flight.
+        # asyncio.run() then cancels it during loop teardown and
+        # _run_custom's CancelledError handler rewrites the status to
+        # "aborted" -- which is what made these tests fail ~25% of runs.
+        await run.task
         assert run.status == "running"  # never touched Done/set_status
 
         overwritten = await manager.start_custom_job(
             "Manualpick", "Manual Picking", factory, field_values=values,
             overwrite_run_id=run.run_id, stays_running=True,
         )
-        for _ in range(200):
-            await asyncio.sleep(0.02)
-            if overwritten.status != "pending":
-                break
+        # Await the task rather than polling for a status change:
+        # _run_custom sets "running" as its FIRST action, so a poll on
+        # `status != "pending"` returns while the task is still in flight.
+        # asyncio.run() then cancels it during loop teardown and
+        # _run_custom's CancelledError handler rewrites the status to
+        # "aborted" -- which is what made these tests fail ~25% of runs.
+        await overwritten.task
         return run, overwritten
 
     run, overwritten = asyncio.run(go())

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1231,22 +1231,109 @@ became variables (`--console-bg`, `--console-bg-deep`, `--console-text`) so they
 restyle too. Chart series colours are separate, mode-specific values validated
 against each surface rather than an automatic flip.
 
+## Transport security (TLS)
+
+Off by default, on with `Run-RelionUS --tls`, and the control that actually
+makes the rest of this section meaningful: without it the password, the
+session cookie, project paths, job commands and Terminal output all cross the
+network in cleartext, and the strength of the password hash is irrelevant
+because an attacker on the path reads the password rather than the hash.
+
+Served by uvicorn's own SSL support (`--ssl-certfile`/`--ssl-keyfile`), not by
+anything this app implements. `auth.generate_self_signed_cert()` shells out to
+`openssl req -x509` for a 4096-bit key and an 825-day certificate — 825 days
+being the CA/Browser Forum maximum for a publicly-trusted leaf, which Safari
+enforces on *all* certificates, self-signed included. The SAN covers the named
+host plus `localhost`/`127.0.0.1`/`::1`, because the usual way to reach this
+app is an SSH tunnel to localhost even when the certificate names the real
+host, and every current browser rejects a certificate whose SAN doesn't match
+(CN alone has not been accepted for years). The generated key is chmod'd
+`0600` — openssl writes it at the umask otherwise, which is usually
+world-readable.
+
+openssl rather than the `cryptography` package deliberately: openssl is
+already present anywhere RELION is (RELION links it), and the install story
+here is "no more dependencies than necessary".
+
+`auth.cert_fingerprint()` prints the SHA-256, which is what makes a
+self-signed certificate genuinely checkable — comparing it against what the
+browser shows rules out a man-in-the-middle, i.e. supplies by hand the one
+guarantee a CA would otherwise provide. Encryption itself is identical either
+way (TLS 1.3 / AES-256-GCM in testing); what a CA sells is *identity*.
+
+`main.py`'s `_is_secure_request()` reads `X-Forwarded-Proto` as well as the
+URL scheme, so a TLS-terminating reverse proxy — where the app itself only
+ever sees plain HTTP — still gets a `Secure` cookie. That header is
+client-settable and therefore only ever used to *add* protection, never to
+grant access: a forged one can make a plain-HTTP client's own cookie stricter
+than needed, which benefits no attacker.
+
+HSTS is opt-in (`--hsts` → `RELION_US_HSTS=1`) rather than automatic. It is
+right in front of a real certificate and a self-inflicted lockout in front of
+a self-signed one being evaluated, since it is a one-way door for that
+hostname.
+
 ## Password protection
 
-Off by default, and deliberately not real security — see `backend/auth.py`'s
-module docstring for the full threat-model reasoning (no TLS is set up
-here, so the password crosses the network in plain text like everything
-else this app sends; this is a deterrent against casual access on a shared
-lab/cluster network, not a hardened login).
+Off by default. Layered *under* TLS, not instead of it: encryption stops
+eavesdropping, the password stops the person at the next workstation.
 
 **Storage.** `project_manager.config_root() / "auth.json"` — per-*user*,
 alongside the recent-projects cache (`project_manager.recents_path()`; both
 now go through the shared `config_root()` helper), not per-project, since
-the whole point is protecting the app before it even shows a project. Only
-a salted PBKDF2-SHA256 hash is stored (stdlib `hashlib.pbkdf2_hmac`, no new
-dependency for bcrypt/argon2 — the iteration count is tuned for "a real cost
-per guess," not for defending a password worth targeting with a GPU), never
-the password itself, and the file is chmod'd `0600` best-effort on save.
+the whole point is protecting the app before it even shows a project. Only a
+salted hash is stored, never the password itself.
+
+**Hashing is scrypt** (stdlib `hashlib.scrypt`, RFC 7914) at n=2¹⁵, r=8, p=1 —
+the RFC's own interactive-login parameters, ~32 MB and ~0.12 s per guess.
+Memory-hardness is the point: it is what prices a GPU/ASIC farm out, where
+PBKDF2 is merely slow. OpenSSL refuses scrypt above a 32 MB default unless
+`maxmem` is raised explicitly, so `SCRYPT_MAXMEM` is passed on every call —
+without it `hashlib.scrypt` raises "memory limit exceeded" at exactly these
+parameters. Still no new dependency (no bcrypt, no argon2).
+
+**PBKDF2 hashes are migrated, not broken.** An install predating this has a
+PBKDF2-SHA256 hash and no `kdf` key at all; `load_config()` back-fills that to
+`pbkdf2_sha256`, `verify_password()` dispatches on it, and
+`upgrade_hash_if_needed()` re-hashes to scrypt on the next successful login —
+the one moment the plaintext exists to re-hash with. It deliberately does not
+rotate the session secret the way `set_password()` does: the password hasn't
+changed, so logging every device out would be a confusing side effect of an
+upgrade nobody asked for. An unknown `kdf` (a config written by a *newer*
+build) refuses the login rather than falling through to "no password set".
+
+**Online guessing is bounded separately** (`login_attempt_allowed` /
+`record_failed_login`). The KDF cost prices *offline* guessing against a
+stolen `auth.json`; 0.12 s per attempt is no obstacle at all to a script
+POSTing `/api/auth/login` in a loop, and the previous fixed `asyncio.sleep(0.5)`
+rate-limited one connection while fifty in parallel went unaffected. Five
+failures from one address within five minutes locks that address out for five
+minutes, with a 4× looser global bucket as a backstop so rotating source
+addresses can't walk around it (equal limits would let one clumsy user lock
+out the whole instance). Held in memory, not persisted: a restart clears it,
+but restarting the backend already requires a shell on that machine, at which
+point `auth.json` is readable directly. The check runs *before* the KDF, so
+the endpoint is neither a guessing oracle nor a cheap way to exhaust 32 MB of
+memory per request. Verification and re-hashing both run via
+`asyncio.to_thread` — scrypt holds the GIL for its whole run, and hashing
+inline would stall every other request and websocket for ~0.12 s per attempt.
+
+**Password rules are a floor, not a strength meter** (`_password_complaint`):
+8 characters minimum, a short list of the passwords a script tries first is
+refused, and fewer than 3 distinct characters is refused. No composition
+rules — length is what predicts guessing cost, while "must contain a symbol"
+mostly produces `Password1!`, which is in every wordlist. This follows NIST
+SP 800-63B (long minimum, screen against known-common values, no composition
+rules, no forced rotation).
+
+**`auth.json` is written 0600-from-creation and atomically.** The previous
+`write_text()` + `chmod()` created the file at the umask and tightened it a
+moment later — a real window on the shared login node this feature exists for,
+winnable with a loop. `os.open(..., 0o600)` passes the mode to the creating
+syscall instead. Writing to a temp file in the same directory and
+`os.replace()`-ing it is atomic on POSIX, so a crash mid-write can't leave a
+truncated `auth.json` that `load_config()` would read as "no password set" —
+silently turning protection off.
 
 **Sessions are stateless**, not a server-side table: the cookie is
 `{expiry}.{HMAC-SHA256(expiry, session_secret)}`, so validity is just
@@ -1273,7 +1360,17 @@ individually.
   than accepting then closing) is what makes Starlette reject the connection
   at the HTTP-upgrade handshake itself (a clean `403`, confirmed against a
   real client in testing) instead of completing the handshake and closing
-  a second later.
+  a second later. `/ws/terminal` carries the identical re-check, for the same
+  reason and with more at stake — it is a real interactive shell.
+
+**Response headers** (`security_headers` middleware, `main.py`) are set on
+every response regardless of whether auth is on: `X-Content-Type-Options:
+nosniff`, `X-Frame-Options: DENY` (framing this is the setup for clickjacking
+a Run button), and `Referrer-Policy: same-origin` (project paths shouldn't
+leak in a Referer). There is deliberately **no CORS middleware at all** — the
+frontend is same-origin, and a permissive policy here was previously enough
+to let any web page the user visited drive `/api/runs`, i.e. run arbitrary
+shell commands. See that middleware's own comment.
 
 **The CLI is the only way in or out of this.** There is deliberately no
 in-browser "change password" or "turn this on" control — anyone who can


### PR DESCRIPTION
Makes the app actually secure on the wire, and hardens the password layer that sits on top of it.

## The premise, corrected

**The password hashing was never the weak part.** It was already PBKDF2-HMAC-SHA256 at 260,000 iterations with a per-password random salt and a constant-time compare — a real, correctly-tuned KDF at OWASP's recommended setting (~0.16s per guess, measured). That is the same category of protection as bcrypt/scrypt/argon2, not a different league.

**The weak part was that there was no TLS.** The password, the session cookie, project paths, job commands and Terminal output all crossed the network in cleartext. Against an attacker on the path, how well the password is hashed at rest is irrelevant — they read the password itself, not the hash. That is exactly why the app's own docs said "not real security".

So this PR adds the missing transport layer first, then upgrades what sits on it.

## HTTPS

```bash
./Run-RelionUS --make-cert    # generate a certificate and key (once)
./Run-RelionUS --tls          # serve HTTPS with it
```

- Served by uvicorn's own SSL support (`--ssl-certfile`/`--ssl-keyfile`). `--tls-cert`/`--tls-key` take a real certificate instead; `--make-cert` records its paths so plain `--tls` finds them later.
- `--make-cert` shells out to `openssl` rather than adding `cryptography` to requirements — openssl is already present anywhere RELION is, since RELION links it.
- 4096-bit RSA, 825 days (the CA/Browser Forum ceiling Safari enforces on *all* certificates, self-signed included), SAN covering the named host plus `localhost`/`127.0.0.1`/`::1`. That SAN matters: the usual way in is an SSH tunnel to localhost even when the certificate names the real host, and every current browser rejects a certificate whose SAN doesn't match — CN alone hasn't been accepted for years. Private key is `chmod 0600`; openssl writes it at the umask otherwise.
- `--make-cert` and `--auth-status` print the SHA-256 fingerprint. That is what makes a self-signed certificate genuinely checkable: compare it against what the browser shows and a man-in-the-middle is ruled out — supplying by hand the one guarantee a CA otherwise provides. Encryption is identical either way; what a CA sells is *identity*.
- **Session cookie gets `Secure` whenever the connection is HTTPS**, read from `X-Forwarded-Proto` as well as the URL scheme so a TLS-terminating reverse proxy still gets it. Deliberately not hard-coded — a `Secure` cookie is never sent over plain HTTP, so that would silently break every non-TLS install (login appears to succeed, every subsequent request 401s). `logout` now repeats the same attributes, or the browser keeps a cookie set under HTTPS and Log out does nothing.
- HSTS is opt-in (`--hsts`), not automatic: correct in front of a real certificate, a self-inflicted lockout in front of a self-signed one still being evaluated.
- The launcher warns when serving plain HTTP on a non-loopback address.

Verified against a live instance: TLS 1.3 / AES-256-GCM, certificate verified, `HttpOnly; SameSite=lax; Secure` set. Plain HTTP confirmed unaffected with `Secure` correctly absent.

## Password

- **scrypt** (stdlib `hashlib.scrypt`, RFC 7914) at n=2¹⁵, r=8, p=1 — the RFC's own interactive-login parameters, ~32 MB and ~0.12s per guess. Memory-hardness is the point: it prices out GPU/ASIC farms where PBKDF2 is merely slow. OpenSSL refuses scrypt above a 32 MB default unless `maxmem` is raised explicitly, or `hashlib.scrypt` raises "memory limit exceeded" at exactly these parameters.
- **Existing PBKDF2 hashes still verify and self-upgrade** to scrypt on the next successful login — the one moment the plaintext exists to re-hash with. Nobody resets a password. The session secret is deliberately *not* rotated, since the password hasn't changed and logging every device out would be a confusing side effect. An unknown `kdf` (a config written by a newer build) refuses the login rather than falling through to "no password set".
- **Login lockout**: 5 failures from one address within 5 minutes locks it for 5 minutes, with a 4× looser global bucket so rotating source addresses can't walk around it (equal limits would let one clumsy user lock out the whole instance). Checked *before* the KDF runs, so the endpoint is neither a guessing oracle nor a cheap way to burn 32 MB per request. The previous fixed `asyncio.sleep(0.5)` rate-limited one connection while fifty in parallel went unaffected.
- Hashing moved to `asyncio.to_thread` — scrypt holds the GIL for its whole run and would otherwise stall every request and websocket for ~0.12s per login attempt.
- **Minimum length 8** (was 4), plus the handful of passwords a script tries first. No composition rules, per NIST SP 800-63B: length predicts guessing cost, while "must contain a symbol" mostly produces `Password1!`.
- **`auth.json` is created 0600 by `os.open`** rather than `write_text()` then `chmod()` — that window is winnable with a loop on exactly the shared login node this feature exists for. Written via temp file + `os.replace()`, so a crash mid-write can't leave a truncated file that `load_config()` reads as "no password set", silently turning protection off.

Also adds `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY` and `Referrer-Policy: same-origin` on every response.

## Still not done, on purpose

One shared password, not per-user accounts — so there's still nothing here to audit who did what. And anyone logged in can run arbitrary shell commands, because that is the app's entire purpose; access to it should be treated as equivalent to shell access on that machine. Both are stated plainly in the README.

## Unrelated flaky test, fixed

Found while verifying, and **confirmed pre-existing on the base commit** (reproduced at ~25% failure there in a clean worktree, so not a regression from this PR). 12 tests in `test_custom_jobs.py` polled for `status != "pending"`, which `_run_custom` sets as its *first* action — so they returned while the task was still in flight, `asyncio.run` cancelled it during loop teardown, and the `CancelledError` handler rewrote the status to `"aborted"`. They now await the task. 10/10 clean afterwards, where it previously failed roughly one run in four.

## Testing

Full suite green: **1188 backend tests** (up 13 — new coverage for scrypt hashing, the PBKDF2→scrypt migration including the no-`kdf` legacy config shape, unknown-KDF refusal, and all five lockout behaviours) plus all eight browser suites via `./run_tests.sh all`.

Docs updated in `README.md` (new "Security: HTTPS and the password" section) and `docs/ARCHITECTURE.md` (new "Transport security (TLS)" section, rewritten "Password protection"), including removing the "deliberately not real security" framing that is no longer accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPXykJkAEQXSxD4ey3TqcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPXykJkAEQXSxD4ey3TqcU)_