### PR TITLE
Refuse --hsts with a self-signed certificate; document lockout recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,10 +195,46 @@ close that gap:
   ```
 
 With a real CA-issued certificate you can also add `--hsts`, which tells
-browsers to refuse plain HTTP to this host for a year. Deliberately off by
-default and **not** recommended with a self-signed certificate: it's a
-one-way door that will lock you out of `http://` on that hostname while
-you're still evaluating.
+browsers to refuse plain HTTP to this host for a year. It's off by default,
+and **refused outright with a self-signed certificate** — `--hsts-force`
+overrides that, but read the next section before you use it.
+
+### Recovering from HSTS
+
+Worth understanding before turning `--hsts` on, because this is the one
+setting here you cannot undo from the machine running the app.
+
+`Strict-Transport-Security: max-age=31536000` is cached **by the browser**,
+not held by the server. Dropping `--hsts`, restarting, even deleting the
+certificate changes nothing — the browser already has the policy and will
+honour it for a year.
+
+With a self-signed certificate it's worse than inconvenient. HSTS
+deliberately removes the click-through on certificate warnings ([RFC 6797
+§12.1](https://datatracker.ietf.org/doc/html/rfc6797#section-12.1) — "there
+is no such recourse"), so the browser refuses plain HTTP to that host *and*
+refuses to let you accept the untrusted certificate. Both doors, for a year,
+in every browser that saw the header. That's why `--make-cert` certificates
+are refused: `Run-RelionUS` checks whether the certificate is self-signed
+(issuer equals subject) and won't arm HSTS if it is.
+
+There's a server-side escape in principle — serve `max-age=0` over HTTPS and
+the browser drops the pin — but it needs a handshake the browser will
+complete, which under an active pin with an untrusted certificate it won't.
+So it works with a real certificate and is unavailable in exactly the
+self-signed case where you'd need it.
+
+If you've already locked yourself out, clear the HSTS entry per browser:
+
+| Browser | How |
+|---|---|
+| Chrome / Edge | Open `chrome://net-internals/#hsts`, put the hostname in **Delete domain security policies**, click Delete |
+| Firefox | History ▸ find the site ▸ **Forget About This Site**; or close Firefox and delete `SiteSecurityServiceState.txt` from the profile folder |
+| Safari | Quit Safari, delete `~/Library/Cookies/HSTS.plist`, reopen |
+
+A different hostname for the same machine (say the IP instead of the name)
+is unaffected, since HSTS is stored per host — a quick way back in while you
+sort the browser out.
 
 A TLS-terminating reverse proxy (nginx/Caddy) in front of the app also works
 and is a perfectly good choice if you already run one. The app reads
@@ -255,6 +291,15 @@ How the password is protected:
   cost only prices *offline* guessing against a stolen config file; 0.12 s per
   try is no obstacle to a script hammering the login endpoint, so that needs
   its own control.
+
+  **If you lock yourself out**, the correct password is refused too — that's
+  deliberate, or the lockout would be trivially bypassable. Two ways back:
+  wait 5 minutes, or **restart the backend** (Ctrl-C and relaunch), which
+  clears it instantly. The counters live in memory in the server process and
+  are never written to disk. There is deliberately no `--clear-lockout` flag:
+  a CLI invocation is a *separate* Python process with its own empty
+  counters, so it would report success and change nothing in the running
+  server. Restarting is the mechanism, not a workaround for a missing one.
 - **Minimum 8 characters**, and the handful of passwords every guessing script
   tries first are refused. No composition rules — length is what actually
   predicts guessing cost, and "must contain a symbol" mostly produces

--- a/Run-RelionUS
+++ b/Run-RelionUS
@@ -80,6 +80,8 @@ PORT="8420"
 TLS_CERT=""
 TLS_KEY=""
 WANT_TLS=0
+WANT_HSTS=0
+HSTS_FORCE=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --host) [[ $# -ge 2 ]] || { echo "--host needs a value" >&2; exit 1; }; HOST="$2"; shift 2 ;;
@@ -93,7 +95,8 @@ while [[ $# -gt 0 ]]; do
       if [[ $# -ge 2 && "$2" != -* ]]; then run_auth_cli make-cert "$2"; else run_auth_cli make-cert; fi
       exit $?
       ;;
-    --hsts) export RELION_US_HSTS=1; shift ;;
+    --hsts) WANT_HSTS=1; shift ;;
+    --hsts-force) WANT_HSTS=1; HSTS_FORCE=1; shift ;;
     --set-password) run_auth_cli set-password; exit $? ;;
     --enable-auth) run_auth_cli enable; exit $? ;;
     --disable-auth) run_auth_cli disable; exit $? ;;
@@ -108,8 +111,10 @@ while [[ $# -gt 0 ]]; do
       echo
       echo "  --tls    serve HTTPS. Without it everything, the password"
       echo "           included, crosses the network in plain text."
-      echo "  --hsts   send Strict-Transport-Security (only with a real,"
-      echo "           CA-issued certificate -- see README)."
+      echo "  --hsts   send Strict-Transport-Security. Refused with a"
+      echo "           self-signed certificate: it is cached by the browser"
+      echo "           for a year and cannot be undone from this machine."
+      echo "           --hsts-force overrides (read the README first)."
       exit 0
       ;;
     *)
@@ -151,6 +156,29 @@ if [[ "$WANT_TLS" == "1" ]]; then
     [[ -r "$f" ]] || { echo "Cannot read TLS file: $f" >&2; exit 1; }
   done
   SSL_ARGS=(--ssl-certfile "$TLS_CERT" --ssl-keyfile "$TLS_KEY")
+fi
+
+# --hsts is the one setting here a user cannot undo from this machine: the
+# max-age is cached by the BROWSER, so turning the flag off again does nothing.
+# With a self-signed certificate it also removes the click-through on the
+# certificate warning, costing both http:// and https:// on this hostname
+# until HSTS state is cleared in every browser by hand. So it is gated on what
+# the certificate actually is -- exit 2 from hsts-check means "self-signed,
+# refuse"; exit 1 means "couldn't verify, warn and continue".
+if [[ "$WANT_HSTS" == "1" ]]; then
+  if [[ "$WANT_TLS" != "1" ]]; then
+    echo "--hsts needs --tls: the header is only ever sent over HTTPS." >&2
+    exit 1
+  fi
+  if [[ "$HSTS_FORCE" == "1" ]]; then
+    run_auth_cli hsts-check "$TLS_CERT" force || true
+  else
+    run_auth_cli hsts-check "$TLS_CERT" && hsts_rc=0 || hsts_rc=$?
+    if [[ "${hsts_rc:-0}" == "2" ]]; then
+      exit 1                    # hsts-check already explained why, on stderr
+    fi
+  fi
+  export RELION_US_HSTS=1
 fi
 
 # Asked every time protection isn't currently in effect for this run --

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -496,6 +496,93 @@ def cert_fingerprint(cert_path: Path) -> str:
     return (proc.stdout or "").strip().split("=", 1)[-1].strip()
 
 
+# --- Is this certificate one HSTS is safe to send with? ---------------------
+#
+# HSTS is the one setting in this app that a user cannot undo from the machine
+# they are on. `Strict-Transport-Security: max-age=31536000` is cached BY THE
+# BROWSER for a year; turning the flag back off, restarting, even deleting the
+# certificate changes nothing, because the server was never holding the state.
+#
+# With a self-signed certificate that is not merely inconvenient, it is a
+# lockout with no way back: HSTS deliberately removes the click-through on
+# certificate warnings (RFC 6797 §12.1 -- "there is no such recourse"), so the
+# browser will refuse plain HTTP to that host AND refuse to let anyone accept
+# the untrusted certificate. Both doors, for a year, per browser.
+#
+# The server-side escape (serving `max-age=0` to clear the pin) needs a
+# handshake the browser will complete -- which under an active pin with an
+# untrusted certificate it won't. So the remedy exists exactly where it isn't
+# needed and is unavailable exactly where it is.
+#
+# Hence: classify the certificate before letting --hsts arm.
+
+TRUST_TRUSTED = "trusted"
+TRUST_SELF_SIGNED = "self_signed"
+TRUST_UNVERIFIED = "unverified"
+
+
+def certificate_trust(cert_path: Path) -> tuple[str, str]:
+    """Classify a certificate as (status, human-readable detail).
+
+    Three outcomes, deliberately not two:
+
+    * TRUST_SELF_SIGNED -- issuer equals subject. This is what --make-cert
+      produces, and the case that bricks a hostname under HSTS. Refused.
+    * TRUST_UNVERIFIED -- chains to something, but this machine's trust store
+      can't verify it (a private/institutional CA whose root isn't installed
+      here, or an expired certificate). Warned about, not refused: a private CA
+      IS usually installed in the browsers that matter even when it isn't in
+      this machine's OpenSSL store, so refusing outright would be a false
+      positive on a deliberate, well-understood setup.
+    * TRUST_TRUSTED -- verifies against the system store. HSTS is fine.
+
+    Biased toward the safe answer only where the answer is unambiguous
+    (issuer == subject is not a heuristic), because a false refusal costs one
+    override flag while a false pass costs a year of that hostname.
+    """
+    cert_path = Path(cert_path)
+    try:
+        meta = subprocess.run(
+            ["openssl", "x509", "-in", str(cert_path), "-noout", "-issuer", "-subject"],
+            capture_output=True, text=True, timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return TRUST_UNVERIFIED, f"could not read the certificate ({exc})"
+    if meta.returncode != 0:
+        return TRUST_UNVERIFIED, (meta.stderr or "could not read the certificate").strip()
+
+    fields = {}
+    for line in (meta.stdout or "").splitlines():
+        key, _, value = line.partition("=")
+        fields[key.strip()] = value.strip()
+    issuer, subject = fields.get("issuer"), fields.get("subject")
+    if issuer and subject and issuer == subject:
+        return TRUST_SELF_SIGNED, f"self-signed (issuer and subject are both {subject})"
+
+    # -untrusted <the file itself> so a fullchain.pem's own bundled
+    # intermediates are used; without it a perfectly good Let's Encrypt
+    # certificate fails to verify for lack of its intermediate.
+    try:
+        verify = subprocess.run(
+            ["openssl", "verify", "-untrusted", str(cert_path), str(cert_path)],
+            capture_output=True, text=True, timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return TRUST_UNVERIFIED, f"could not verify the certificate chain ({exc})"
+    if verify.returncode == 0:
+        return TRUST_TRUSTED, "verifies against this machine's trust store"
+    # openssl prints the useful reason ("error 20 at 0 depth lookup: unable to
+    # get local issuer certificate") ABOVE its final "error <path>: verification
+    # failed" line, so taking the last line yields only the path back. Prefer
+    # the depth line, which is the part that says what is actually wrong.
+    lines = [ln.strip() for ln in (verify.stderr or verify.stdout or "").splitlines() if ln.strip()]
+    reason = next((ln.split("depth lookup:", 1)[1].strip()
+                   for ln in lines if "depth lookup:" in ln), None)
+    if reason is None:
+        reason = next((ln for ln in lines if not ln.startswith("error ")), None)
+    return TRUST_UNVERIFIED, f"could not be verified here ({reason or 'chain incomplete'})"
+
+
 def enable() -> None:
     cfg = load_config()
     if not cfg.get("password_hash"):
@@ -664,6 +751,59 @@ def cli_make_cert(hostname: str | None = None) -> int:
     return 0
 
 
+def cli_hsts_check(cert: str, forced: bool = False) -> int:
+    """Gate for Run-RelionUS's --hsts. Exit codes, not text, are the contract:
+
+      0  safe -- certificate verifies against the system trust store
+      2  REFUSE -- self-signed; HSTS would brick this hostname per browser
+      1  warn only -- can't be verified here, but isn't self-signed
+
+    Only exit 2 stops the launcher (and only without --hsts-force), because
+    only issuer==subject is a certain answer -- see certificate_trust."""
+    status, detail = certificate_trust(Path(cert))
+    if status == TRUST_TRUSTED:
+        return 0
+    if status == TRUST_SELF_SIGNED and forced:
+        # --hsts-force was passed, so the launcher is going ahead regardless.
+        # Printing the full refusal here and then starting anyway would be
+        # a contradiction; say what is actually about to happen instead.
+        print(f"--hsts-force: sending HSTS with a {detail} certificate.",
+              file=sys.stderr)
+        print("Browsers will refuse plain HTTP to this host for a year, and "
+              "will no longer", file=sys.stderr)
+        print("offer to accept this certificate. Clearing that needs manual "
+              "steps in every", file=sys.stderr)
+        print('browser -- see "Recovering from HSTS" in the README.',
+              file=sys.stderr)
+        return 0
+    if status == TRUST_SELF_SIGNED:
+        print(f"Refusing --hsts: this certificate is {detail}.", file=sys.stderr)
+        print(file=sys.stderr)
+        print("HSTS tells browsers to refuse plain HTTP to this host for a "
+              "year, and it is", file=sys.stderr)
+        print("cached by the BROWSER -- turning the flag off again, restarting, "
+              "or deleting the", file=sys.stderr)
+        print("certificate will not undo it. With a self-signed certificate it "
+              "also removes the", file=sys.stderr)
+        print("click-through on the certificate warning, so you would lose "
+              "both http:// and", file=sys.stderr)
+        print("https:// on this hostname until you clear HSTS state in every "
+              "browser by hand.", file=sys.stderr)
+        print(file=sys.stderr)
+        print("Use --hsts only with a CA-issued certificate (--tls-cert/"
+              "--tls-key). If you", file=sys.stderr)
+        print("genuinely mean it anyway, add --hsts-force -- and read "
+              '"Recovering from HSTS"', file=sys.stderr)
+        print("in the README first.", file=sys.stderr)
+        return 2
+    print(f"Warning: --hsts is on, but this certificate {detail}.", file=sys.stderr)
+    print("If browsers don't trust it either, HSTS will make this hostname "
+          "unreachable", file=sys.stderr)
+    print('until HSTS state is cleared by hand -- see "Recovering from HSTS" '
+          "in the README.", file=sys.stderr)
+    return 1
+
+
 def cli_tls_paths() -> int:
     """Silent except for the paths -- Run-RelionUS reads these to build its
     uvicorn command. Exit 1 (printing nothing) when TLS isn't configured, so
@@ -703,10 +843,15 @@ def main(argv: list[str]) -> int:
             print("Usage: make-cert [hostname]")
             return 2
         return cli_make_cert(argv[1] if len(argv) == 2 else None)
+    if argv and argv[0] == "hsts-check":
+        if len(argv) not in (2, 3) or (len(argv) == 3 and argv[2] != "force"):
+            print("Usage: hsts-check <certificate> [force]")
+            return 2
+        return cli_hsts_check(argv[1], forced=len(argv) == 3)
     if len(argv) != 1 or argv[0] not in commands:
         print(f"Usage: {Path(sys.argv[0]).name} "
               "{status|set-password|enable|disable|is-enabled|tls-paths|"
-              "make-cert [hostname]}")
+              "make-cert [hostname]|hsts-check <cert>}")
         return 2
     return commands[argv[0]]()
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -230,6 +230,78 @@ def test_failures_outside_the_window_do_not_count():
         auth.reset_login_throttle()
 
 
+# --- certificate trust / the --hsts gate -----------------------------------
+# HSTS is the one setting a user cannot undo from the machine they are on
+# (the max-age lives in the browser), and with a self-signed certificate it
+# also removes the click-through on the cert warning -- so the gate that
+# refuses that combination is worth pinning down.
+
+import shutil
+import subprocess
+
+_no_openssl = pytest.mark.skipif(
+    shutil.which("openssl") is None, reason="openssl not on PATH")
+
+
+@_no_openssl
+def test_generated_certificate_is_detected_as_self_signed(auth_home):
+    cert, _key, _fp = auth.generate_self_signed_cert("relion-test.local")
+    status, detail = auth.certificate_trust(cert)
+    assert status == auth.TRUST_SELF_SIGNED
+    assert "relion-test.local" in detail
+
+
+@_no_openssl
+def test_hsts_check_refuses_a_self_signed_certificate(auth_home, capsys):
+    cert, _key, _fp = auth.generate_self_signed_cert("relion-test.local")
+    # Exit 2 is the launcher's "refuse and do not start" signal; 1 is only a
+    # warning. The distinction is the whole point, so assert the exact code.
+    assert auth.cli_hsts_check(str(cert)) == 2
+    err = capsys.readouterr().err
+    assert "--hsts-force" in err
+
+
+@_no_openssl
+def test_hsts_force_proceeds_but_still_warns(auth_home, capsys):
+    cert, _key, _fp = auth.generate_self_signed_cert("relion-test.local")
+    assert auth.cli_hsts_check(str(cert), forced=True) == 0
+    err = capsys.readouterr().err
+    assert "--hsts-force" in err
+    # Must NOT claim to be refusing when it is about to go ahead.
+    assert "Refusing" not in err
+
+
+@_no_openssl
+def test_a_ca_issued_certificate_is_warned_about_not_refused(auth_home, tmp_path, capsys):
+    """A certificate from a private/institutional CA whose root isn't in this
+    machine's store is unverifiable HERE but is usually trusted by the browsers
+    that matter, so refusing it would be a false positive on a deliberate
+    setup. Only issuer==subject -- which is never ambiguous -- is refused."""
+    ca_key, ca_crt = tmp_path / "ca.key", tmp_path / "ca.pem"
+    leaf_key, leaf_csr, leaf = tmp_path / "l.key", tmp_path / "l.csr", tmp_path / "l.pem"
+    subprocess.run(["openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+                    "-keyout", str(ca_key), "-out", str(ca_crt), "-days", "2",
+                    "-subj", "/CN=Test Root CA",
+                    "-addext", "basicConstraints=critical,CA:TRUE"],
+                   check=True, capture_output=True)
+    subprocess.run(["openssl", "req", "-newkey", "rsa:2048", "-nodes",
+                    "-keyout", str(leaf_key), "-out", str(leaf_csr),
+                    "-subj", "/CN=leaf.example"], check=True, capture_output=True)
+    subprocess.run(["openssl", "x509", "-req", "-in", str(leaf_csr),
+                    "-CA", str(ca_crt), "-CAkey", str(ca_key), "-CAcreateserial",
+                    "-out", str(leaf), "-days", "2"], check=True, capture_output=True)
+
+    status, _detail = auth.certificate_trust(leaf)
+    assert status == auth.TRUST_UNVERIFIED
+    assert auth.cli_hsts_check(str(leaf)) == 1        # warn, not refuse
+    assert "Recovering from HSTS" in capsys.readouterr().err
+
+
+def test_certificate_trust_on_a_missing_file_is_unverified_not_a_crash(tmp_path):
+    status, _detail = auth.certificate_trust(tmp_path / "nope.pem")
+    assert status == auth.TRUST_UNVERIFIED
+
+
 # --- enable/disable -------------------------------------------------------
 
 def test_enabling_without_a_password_raises(auth_home):


### PR DESCRIPTION
Follow-up to #70. Closes the one footgun that PR shipped: `--hsts` was guarded only by a README warning, and misusing it is unrecoverable from the machine running the app.

## Why this needed a guard, not a warning

`Strict-Transport-Security: max-age=31536000` is cached **by the browser**, not held by the server. Dropping `--hsts`, restarting, even deleting the certificate changes nothing — the browser already has the policy and honours it for a year.

With a self-signed certificate it's worse than inconvenient. HSTS deliberately removes the click-through on certificate warnings ([RFC 6797 §12.1](https://datatracker.ietf.org/doc/html/rfc6797#section-12.1) — "there is no such recourse"), so the browser refuses plain HTTP to that host **and** refuses to let anyone accept the untrusted certificate. Both doors, for a year, in every browser that saw the header.

There is a server-side escape in principle — serve `max-age=0` and the browser drops the pin — but it needs a handshake the browser will complete, which under an active pin with an untrusted certificate it won't. So the remedy works with a real certificate and is unavailable in exactly the self-signed case where you'd need it.

## The gate

`auth.certificate_trust()` classifies a certificate as `trusted` / `self_signed` / `unverified`. **Three outcomes rather than two, on purpose:**

- `self_signed` (issuer == subject) → **refused**. Never ambiguous, and it's exactly what `--make-cert` produces.
- `unverified` (chains to something this machine's store can't verify) → **warned, not refused**. A certificate from a private or institutional CA is usually trusted by the browsers that matter even when its root isn't in this machine's OpenSSL store, so refusing would be a false positive on a deliberate, well-understood setup.
- `trusted` → fine.

Biased toward the safe answer only where the answer is certain: a false refusal costs one override flag, a false pass costs a year of that hostname.

Chain checking passes `-untrusted <the file itself>` so a real `fullchain.pem` uses its own bundled intermediate — without that a perfectly good Let's Encrypt certificate fails to verify.

`auth.py hsts-check <cert> [force]` exposes this as exit codes (0 safe / 1 warn / 2 refuse), and `Run-RelionUS` gates `--hsts` on it:

```
$ ./Run-RelionUS --tls --hsts
Refusing --hsts: this certificate is self-signed (issuer and subject are both CN = relion-test.local).

HSTS tells browsers to refuse plain HTTP to this host for a year, and it is
cached by the BROWSER -- turning the flag off again, restarting, or deleting the
certificate will not undo it. ...
Use --hsts only with a CA-issued certificate (--tls-cert/--tls-key). If you
genuinely mean it anyway, add --hsts-force -- and read "Recovering from HSTS"
in the README first.
```

`--hsts-force` overrides, and prints what is actually about to happen rather than a refusal it isn't carrying out. `--hsts` without `--tls` is now refused too — the header only ever goes out over HTTPS.

Also fixes the unverified-case message to extract openssl's real reason (`unable to get local issuer certificate`) instead of its trailing `error <path>: verification failed` line, which only echoes the path back.

## Documentation: both lockouts, opposite answers

The question that prompted this was whether either lockout is fixable from a terminal on the running machine. They differ, and neither was documented:

**HSTS — no.** New "Recovering from HSTS" section explains why the server can't fix it, and gives the per-browser steps that can: `chrome://net-internals/#hsts` → Delete domain security policies; Firefox's Forget About This Site or deleting `SiteSecurityServiceState.txt`; Safari's `~/Library/Cookies/HSTS.plist`. Plus the practical note that a different hostname for the same machine (the IP instead of the name) is unaffected, since HSTS is stored per host — the quick way back in.

**Login lockout — yes.** Restart the backend (counters are in memory in the server process) or wait out the 5 minutes. The README now also says why there is deliberately **no** `--clear-lockout` flag: a CLI invocation is a *separate* Python process with its own empty counters, so it would report success and change nothing in the running server. Restarting is the mechanism, not a workaround for a missing one.

Also documents that the correct password is refused during a lockout — deliberate, or the lockout would be trivially bypassable.

## Testing

Five new tests: the classification of a generated certificate, both gate outcomes, that `--hsts-force` does not print "Refusing" while proceeding, that a CA-issued certificate is warned about rather than refused (built with a real throwaway CA in the test), and that a missing file is `unverified` rather than a crash. They skip cleanly if `openssl` isn't on PATH.

Verified by hand against a running instance: `--hsts` refused and did not start (exit 1); `--hsts-force` started and the header was actually present on the response; `--hsts` without `--tls` refused.

Full suite green: **1193 backend tests** plus all eight browser suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPXykJkAEQXSxD4ey3TqcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPXykJkAEQXSxD4ey3TqcU)_